### PR TITLE
Fix macOS actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
           CFLAGS="${CFLAGS}" \
           CXXFLAGS="${CFLAGS} -std=c++11" \
           VERSION="${LDID_VERSION}" \
-          LIBS="/opt/procursus/lib/libplist-2.0.a /opt/procursus/lib/libcrypto.a"
+          LIBS="${LIBS}"
         strip ldid
 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,15 +168,15 @@ jobs:
           build-macos-${{ matrix.arch }}-
 
     - name: Setup Procursus Bootstrap (install)
-        if: steps.cache.outpus.cache-hit != 'true'
-        run: |
-          wget https://apt.procurs.us/bootstrap_darwin-amd64.tar.zst https://apt.procurs.us/Toolchain12_5.tzst
-          sudo gtar --preserve-permissions -xkf ./bootstrap_darwin-amd64.tar.zst -C /
-          echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
-          PATH=/opt/procursus/sbin:/opt/procursus/bin:$PATH sudo /opt/procursus/bin/apt update
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y || :
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y
-          sudo /opt/procursus/bin/apt install -y libssl-dev libplist-dev
+      if: steps.cache.outpus.cache-hit != 'true'
+      run: |
+        wget https://apt.procurs.us/bootstrap_darwin-amd64.tar.zst https://apt.procurs.us/Toolchain12_5.tzst
+        sudo gtar --preserve-permissions -xkf ./bootstrap_darwin-amd64.tar.zst -C /
+        echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
+        PATH=/opt/procursus/sbin:/opt/procursus/bin:$PATH sudo /opt/procursus/bin/apt update
+        sudo /opt/procursus/bin/apt -V dist-upgrade -y || :
+        sudo /opt/procursus/bin/apt -V dist-upgrade -y
+        sudo /opt/procursus/bin/apt install -y libssl-dev libplist-dev
 
     - name: Add Procursus to PATH
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,11 +210,11 @@ jobs:
         wget -q -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
         tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
         cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./config --prefix=/usr no-shared darwin64-${ARCH}
-        make -j$(sysctl -n hw.ncpu) build_generated libcrypto.a
+        ./Configure --prefix=/usr no-shared no-tests darwin64-${ARCH}
+        make -j$(sysctl -n hw.ncpu) install_dev DESTDIR="${DEP_PATH}/openssl-destdir"
 
-        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
-        echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
+        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-destdir/usr/include" >> $GITHUB_ENV
+        echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-destdir/lib/libcrypto.a" >> $GITHUB_ENV
 
     - name: build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
     - name: setup toolchain
       run: |
         brew install libtool autoconf automake
+        brew uninstall --force openssl
 
         # Download sccache
         wget -nc -P ${DOWNLOAD_PATH} \
@@ -204,10 +205,6 @@ jobs:
 
         echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
         echo "LIBPLIST_LIB=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
-
-    - name: Does brew install openssl?
-      run: |
-        find / -name 'opensslv.h'
 
     - name: build openssl
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,12 +199,6 @@ jobs:
         echo "DOWNLOAD_PATH=${DOWNLOAD_PATH}" >> $GITHUB_ENV
         echo "DEP_PATH=${DEP_PATH}" >> $GITHUB_ENV
 
-        if [ "${ARCH}" = "arm64" ]; then
-          echo "HOST_ARCH=aarch64" >> $GITHUB_ENV
-        else
-          echo "HOST_ARCH=${ARCH}" >> $GITHUB_ENV
-        fi
-
     - name: setup toolchain
       run: |
 
@@ -213,6 +207,18 @@ jobs:
           https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz
         tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz -C ${HOME}
         chmod +x ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin/sccache
+
+        if [ "${ARCH}" = "arm64" ]; then
+          wget -nc -P ${DOWNLOAD_PATH} \
+            https://apt.procurs.us/pool/main/big_sur/libssl-dev_${OPENSSL_VERSION}_darwin-arm64.deb
+          dpkg -x ${DOWNLOAD_PATH}/libssl-dev_${OPENSSL_VERSION}_darwin-arm64.deb ${DEP_PATH}
+          wget -nc -P ${DOWNLOAD_PATH} \
+            https://apt.procurs.us/pool/main/big_sur/libplist-dev_${LIBPLIST_VERSION}_darwin-arm64.deb
+          dpkg -x ${DOWNLOAD_PATH}/libplist-dev_${LIBPLIST_VERSION}_darwin-arm64.deb ${DEP_PATH}
+          echo "LIBS=${DEP_PATH}/opt/procursus/lib/libplist-2.0.a ${DEP_PATH}/opt/procursus/lib/libcrypto.a" >> $GITHUB_ENV
+        else
+          echo "LIBS=/opt/procursus/lib/libplist-2.0.a /opt/procursus/lib/libcrypto.a" >> $GITHUB_ENV
+        fi
 
         echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
         echo "CC=sccache clang -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,13 +157,39 @@ jobs:
         submodules: recursive
 
     - uses: actions/cache@v2
+      id: cache
       with:
         path: |
           ~/Library/Caches/Mozilla.sccache
           ~/dep_src
+          ~/__cache
         key: build-macos-${{ matrix.arch }}-${ { env.GITHUB_SHA } }
         restore-keys: |
           build-macos-${{ matrix.arch }}-
+
+    - name: Setup Procursus Bootstrap (install)
+        if: steps.cache.outpus.cache-hit != 'true'
+        run: |
+          wget https://apt.procurs.us/bootstrap_darwin-amd64.tar.zst https://apt.procurs.us/Toolchain12_5.tzst
+          sudo gtar --preserve-permissions -xkf ./bootstrap_darwin-amd64.tar.zst -C /
+          echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
+          PATH=/opt/procursus/sbin:/opt/procursus/bin:$PATH sudo /opt/procursus/bin/apt update
+          sudo /opt/procursus/bin/apt -V dist-upgrade -y || :
+          sudo /opt/procursus/bin/apt -V dist-upgrade -y
+          sudo /opt/procursus/bin/apt install -y libssl-dev libplist-dev
+
+    - name: Add Procursus to PATH
+      run: |
+        echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
+
+    - name: Setup Procursus Bootstrap (cache)
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: |
+        sudo mkdir -p ~/__cache/procursus/var/cache/apt/archives/partial ~/__cache/procursus/var/lib/apt/lists/partial
+        sudo rsync -aP ~/__cache/procursus /opt
+        sudo /opt/procursus/bin/apt update
+        sudo /opt/procursus/bin/apt -V dist-upgrade -y
+        sudo /opt/procursus/bin/apt -V dist-upgrade -y
 
     - name: setup environment
       run: |
@@ -181,8 +207,6 @@ jobs:
 
     - name: setup toolchain
       run: |
-        brew install libtool autoconf automake
-        brew uninstall --force openssl
 
         # Download sccache
         wget -nc -P ${DOWNLOAD_PATH} \
@@ -193,37 +217,16 @@ jobs:
         echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
         echo "CC=sccache clang -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
         echo "CXX=sccache clang++ -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
-        echo "CFLAGS=-Os" >> $GITHUB_ENV
-
-    - name: build libplist
-      run: |
-        wget -q -nc -P ${DOWNLOAD_PATH} https://github.com/libimobiledevice/libplist/releases/download/${LIBPLIST_VERSION}/libplist-${LIBPLIST_VERSION}.tar.bz2
-        tar xf ${DOWNLOAD_PATH}/libplist-${LIBPLIST_VERSION}.tar.bz2 -C ${DEP_PATH}
-        cd ${DEP_PATH}/libplist-${LIBPLIST_VERSION}
-        ./configure --host=${HOST_ARCH}-apple-darwin --without-cython --enable-static --disable-shared
-        make -j$(sysctl -n hw.ncpu)
-
-        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
-        echo "LIBPLIST_LIB=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
-
-    - name: build openssl
-      run: |
-        wget -q -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-        tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
-        cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./Configure --prefix=/usr no-shared no-tests darwin64-${ARCH}
-        make -j$(sysctl -n hw.ncpu) install_dev DESTDIR="${DEP_PATH}/openssl-destdir"
-
-        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-destdir/usr/include" >> $GITHUB_ENV
-        echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-destdir/usr/lib/libcrypto.a" >> $GITHUB_ENV
+        echo "CFLAGS=-Os -I/opt/procursus/include -flto=thin" >> $GITHUB_ENV
 
     - name: build
       run: |
         export LDID_VERSION=$(echo "$(git describe --tags --abbrev=0)")
         make -j$(sysctl -n hw.ncpu) \
-          CFLAGS="${CFLAGS} -flto=thin" \
+          CFLAGS="${CFLAGS}" \
+          CXXFLAGS="${CFLAGS}" \
           VERSION="${LDID_VERSION}" \
-          LIBS="${LIBPLIST_LIB} ${LIBCRYPTO_LIB}"
+          LIBS="/opt/procursus/lib/libplist-2.0.a /opt/procursus/lib/libcrypto.a"
         strip ldid
 
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,10 @@ jobs:
         echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
         echo "LIBPLIST_LIB=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
 
+    - name: Does brew install openssl?
+      run: |
+        find / -name 'opensslv.h'
+
     - name: build openssl
       run: |
         wget -q -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
@@ -214,7 +218,7 @@ jobs:
         make -j$(sysctl -n hw.ncpu) install_dev DESTDIR="${DEP_PATH}/openssl-destdir"
 
         echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-destdir/usr/include" >> $GITHUB_ENV
-        echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-destdir/lib/libcrypto.a" >> $GITHUB_ENV
+        echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-destdir/usr/lib/libcrypto.a" >> $GITHUB_ENV
 
     - name: build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,8 +221,8 @@ jobs:
         fi
 
         echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
-        echo "CC=sccache clang -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
-        echo "CXX=sccache clang++ -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
+        echo "CC=sccache clang -arch ${ARCH} -mmacosx-version-min=11.0" >> $GITHUB_ENV
+        echo "CXX=sccache clang++ -arch ${ARCH} -mmacosx-version-min=11.0" >> $GITHUB_ENV
         echo "CFLAGS=-Os -I/opt/procursus/include -flto=thin" >> $GITHUB_ENV
 
     - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
         export LDID_VERSION=$(echo "$(git describe --tags --abbrev=0)")
         make -j$(sysctl -n hw.ncpu) \
           CFLAGS="${CFLAGS}" \
-          CXXFLAGS="${CFLAGS}" \
+          CXXFLAGS="${CFLAGS} -std=c++11" \
           VERSION="${LDID_VERSION}" \
           LIBS="/opt/procursus/lib/libplist-2.0.a /opt/procursus/lib/libcrypto.a"
         strip ldid


### PR DESCRIPTION
This changes the macOS actions to use the openssl and libplist builds from Procursus as the ones being built by actions seem to cause numerous issues.