### PR TITLE
Add support for `-arch arch_type`

### DIFF
--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -58,6 +58,7 @@ The list of currently known
 .Ar arch_type Ns s
 can be found in
 .Xr arch 3 .
+This is a Procursus extension.
 .It Fl C Ns Op Ar adhoc | Ar enforcement | Ar expires | Ar hard | Ar host | Ar kill | Ar library-validation | Ar restrict | Ar runtime
 Specify the option flags to embed in the code signature.
 See
@@ -140,6 +141,7 @@ the timestamp will be set to a hash of the Mach-O header.
 Use
 .Ar password
 as the password for the p12 certificate instead of prompting.
+This is a Procursus extension.
 .It Fl u
 If the binary was linked against UIKit, then print the UIKit version that the
 Mach-O binaries were linked against.

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -25,14 +25,13 @@
 .Op Fl r | Fl S Ns Ar file.xml | Fl s
 .Op Fl T Ns Ar timestamp
 .Op Fl u
+.Op Fl arch Ar arch_type
 .Ar
 .Sh DESCRIPTION
 .Nm
 adds SHA1 and SHA256 hashes to a Mach-O file so that they can be run
 on a system that has validation but not signature verification.
 .Bl -tag -width -indent
-.It Fl a
-Print the CPU types and subtypes in hexadecimal.
 .It Fl A Ns Ar cputype : Ns Ar subtype
 When used with
 .Fl a , Fl D , Fl e , Fl h , Fl q ,
@@ -46,6 +45,16 @@ and
 and
 .Ar subtype
 should both be integers.
+.It Fl a
+Print the CPU types and subtypes in hexadecimal.
+.It Fl arch Ar arch_type
+The same as
+.Fl A ,
+except the name of the architecture is used.
+The list of currently know
+.Ar arch_type Ns s
+can be found in
+.Xr arch 3 .
 .It Fl C Ns Op Ar adhoc | Ar enforcement | Ar expires | Ar hard | Ar host | Ar kill | Ar library-validation | Ar restrict | Ar runtime
 Specify the option flags to embed in the code signature.
 See

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -51,7 +51,7 @@ Print the CPU types and subtypes in hexadecimal.
 The same as
 .Fl A ,
 except the name of the architecture is used.
-The list of currently know
+The list of currently known
 .Ar arch_type Ns s
 can be found in
 .Xr arch 3 .

--- a/docs/ldid.zh_CN.1
+++ b/docs/ldid.zh_CN.1
@@ -28,13 +28,13 @@
 .Op Fl r | Fl S Ns Ar 档案.xml | Fl s
 .Op Fl T Ns Ar 时间印章
 .Op Fl u
+.Op Fl arch Ar 架构类型
 .Ar
 .Sh 描述
 .Nm
-把SHA1和SHA256杂凑值加入到Mach-O档案中，让它们能在有验证但没有签署验证的系统上运行。
+把SHA1和SHA256杂凑值加入到Mach-O档案中，
+让它们能在有验证但没有签署验证的系统上运行。
 .Bl -tag -width -indent
-.It Fl a
-以十六进制印出处理器类型和亚类型。
 .It Fl A Ns Ar 处理器类型 : Ns Ar 亚类型
 当和
 .Fl a , Fl D , Fl e , Fl h , Fl q ,
@@ -49,6 +49,18 @@
 和
 .Ar 亚类型
 都应该是整数。
+.It Fl a
+以十六进制印出处理器类型和亚类型。
+.It Fl arch Ar 架构类型
+和
+.Fl A
+一样，不过使用架构的名称。
+已知的
+.Ar 架构类型 Ns s
+可以在
+.Xr arch 3
+中找到。
+这是一个Procursus扩展。
 .It Fl C Ns Op Ar adhoc | Ar enforcement | Ar expires | Ar hard | Ar host | Ar kill | Ar library-validation | Ar restrict | Ar runtime
 设定要在档案中包含的程式码签署选项。
 请看
@@ -88,16 +100,16 @@
 .It Fl K Ns Ar 密錀.p12
 用在
 .Ar 密錀.p12 .
-的身份签署。会给二进位档案有一个有效的签署，令它能够在有签署验证的系统上运行。
+的身份签署。 会给二进位档案有一个有效的签署，令它能够在有签署验证的系统上运行。
 如果
 .Ar 密錀.p12
-有密码的话，你会被询问。也可以用
+有密码的话，你会被询问。 也可以用
 .Fl U
 选项来提供密码。
 .It Fl M
 当和
 .Fl S ,
-一起使用时，和现有的权限合并而不是取代它。在加入权限时有用。
+一起使用时，和现有的权限合并而不是取代它。 在加入权限时有用。
 .It Fl P
 将这个Mach-O二进位档案标示为系统二进位档案。
 .It Fl Q Ns Ar 需求.xml
@@ -131,6 +143,7 @@
 使用
 .Ar 密码
 作为p12证书的密码，而不是询问。
+这是一个Procursus扩展。
 .It Fl u
 如果Mach-O档案有和UIKit链结，印出被链结的UIKit版本。
 .El
@@ -153,7 +166,7 @@
 .Ar 档案
 也会使用在
 .Ar ent.xml ,
-中的权限并把签署标示为特别用途 (adhoc) 签署。.
+中的权限并把签署标示为特别用途 (adhoc) 签署。
 .Pp
 指令:
 .Pp
@@ -182,7 +195,7 @@
 .An Jay \*qSaurik\*q Freeman . 所编写的。
 对iPhoneOS 1.2.0 和 2.0 的支援在2008年4月6号被加入。
 .Fl S
-在2008年6月13日被加入。.
+在2008年6月13日被加入。
 SHA256 支援在2016年8月25日被加入，修正iOS 11支援。
 iOS 14支援在2020年7月31日由
 .An Kabir Oberai .

--- a/docs/ldid.zh_TW.1
+++ b/docs/ldid.zh_TW.1
@@ -28,13 +28,13 @@
 .Op Fl r | Fl S Ns Ar 檔案.xml | Fl s
 .Op Fl T Ns Ar 時間印章
 .Op Fl u
+.Op Fl arch Ar 架構類型
 .Ar
 .Sh 描述
 .Nm
-把SHA1和SHA256雜湊值加入到Mach-O檔案中，讓它們能在有驗證但沒有簽署驗證的系統上運行。
+把SHA1和SHA256雜湊值加入到Mach-O檔案中，
+讓它們能在有驗證但沒有簽署驗證的系統上運行。
 .Bl -tag -width -indent
-.It Fl a
-以十六進制印出處理器類型和亞類型。
 .It Fl A Ns Ar 處理器類型 : Ns Ar 亞類型
 當和
 .Fl a , Fl D , Fl e , Fl h , Fl q ,
@@ -49,6 +49,18 @@
 和
 .Ar 亞類型
 都應該是整數。
+.It Fl a
+以十六進制印出處理器類型和亞類型。
+.It Fl arch Ar 架構類型
+和
+.Fl A
+一樣，不過使用架構的名稱。
+已知的
+.Ar 架構類型 Ns s
+可以在
+.Xr arch 3
+中找到。
+這是一個Procursus擴展。
 .It Fl C Ns Op Ar adhoc | Ar enforcement | Ar expires | Ar hard | Ar host | Ar kill | Ar library-validation | Ar restrict | Ar runtime
 設定要在檔案中包含的程式碼簽署選項。
 請看
@@ -131,6 +143,7 @@
 使用
 .Ar 密碼
 作為p12證書的密碼，而不是詢問。
+這是一個Procursus擴展。
 .It Fl u
 如果Mach-O檔案有和UIKit鏈結，印出被鏈結的UIKit版本。
 .El

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -96,6 +96,8 @@
 
 #include "ldid.hpp"
 
+#include "machine.h"
+
 #define _assert___(line) \
     #line
 #define _assert__(line) \
@@ -195,29 +197,6 @@ Scope<Function_> _scope(const Function_ &function) {
     _scope__(counter, function)
 #define _scope(function) \
     _scope_(__COUNTER__, function)
-
-#define CPU_ARCH_MASK     uint32_t(0xff000000)
-#define CPU_ARCH_ABI64    uint32_t(0x01000000)
-#define CPU_ARCH_ABI64_32 uint32_t(0x02000000)
-
-#define CPU_TYPE_ANY     uint32_t(-1)
-#define CPU_TYPE_VAX     uint32_t( 1)
-#define CPU_TYPE_MC680x0 uint32_t( 6)
-#define CPU_TYPE_X86     uint32_t( 7)
-#define CPU_TYPE_MC98000 uint32_t(10)
-#define CPU_TYPE_HPPA    uint32_t(11)
-#define CPU_TYPE_ARM     uint32_t(12)
-#define CPU_TYPE_MC88000 uint32_t(13)
-#define CPU_TYPE_SPARC   uint32_t(14)
-#define CPU_TYPE_I860    uint32_t(15)
-#define CPU_TYPE_POWERPC uint32_t(18)
-
-#define CPU_TYPE_I386 CPU_TYPE_X86
-
-#define CPU_TYPE_ARM64     (CPU_ARCH_ABI64 | CPU_TYPE_ARM)
-#define CPU_TYPE_POWERPC64 (CPU_ARCH_ABI64 | CPU_TYPE_POWERPC)
-#define CPU_TYPE_X86_64    (CPU_ARCH_ABI64 | CPU_TYPE_X86)
-#define CPU_TYPE_ARM64_32  (CPU_TYPE_ARM | CPU_ARCH_ABI64_32)
 
 struct fat_header {
     uint32_t magic;
@@ -3195,7 +3174,25 @@ int main(int argc, char *argv[]) {
     for (int argi(1); argi != argc; ++argi)
         if (argv[argi][0] != '-')
             files.push_back(argv[argi]);
-        else switch (argv[argi][1]) {
+        else if (strcmp(argv[argi], "-arch") == 0) {
+            bool foundarch = false;
+            flag_A = true;
+            argi++;
+            for (int i = 0; archs[i].name != NULL; i++) {
+                if (strcmp(archs[i].name, argv[argi]) == 0) {
+                    flag_CPUType = archs[i].cputype;
+                    flag_CPUSubtype = archs[i].cpusubtype;
+                    foundarch = true;
+                }
+                if (foundarch)
+                    break;
+            }
+
+            if (!foundarch) {
+                fprintf(stderr, "error: unknown architecture specification flag: -arch %s\n", argv[argi]);
+                exit(1);
+            }
+        } else switch (argv[argi][1]) {
             case 'r':
                 _assert(!flag_s);
                 _assert(!flag_S);

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3080,10 +3080,11 @@ std::string Hex(const uint8_t *data, size_t size) {
 
 static void usage(const char *argv0) {
     fprintf(stderr, "Link Identity Editor %s\n\n", LDID_VERSION);
-    fprintf(stderr, "usage: %s [-Acputype:subtype] [-a] [-C[adhoc | enforcement | expires | hard |\n", argv0);
-    fprintf(stderr, "          host | kill | library-validation | restrict | runtime]] [-D] [-d]\n");
-    fprintf(stderr, "          [-Enum:file] [-e] [-h] [-Kkey.p12 [-Upassword]] [-M] [-P] [-q]\n");
-    fprintf(stderr, "          [-r | -Sfile | -s] [-Ttimestamp] [-u] file ...\n\n");
+    fprintf(stderr, "Usage: %s [-Acputype:subtype] [-a] [-C[adhoc | enforcement | expires | hard |\n", argv0);
+    fprintf(stderr, "            host | kill | library-validation | restrict | runtime]] [-D] [-d]\n");
+    fprintf(stderr, "            [-Enum:file] [-e] [-H[sha1 | sha256]] [-h] [-Iname]\n");
+    fprintf(stderr, "            [-Kkey.p12 [-Upassword]] [-M] [-P] [-Qrequirements.xml] [-q]\n");
+    fprintf(stderr, "            [-r | -Sfile.xml | -s] [-Ttimestamp] [-u] [-arch arch_type] file ...\n");
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "   -S[file.xml]  Pseudo-sign using the entitlements in file.xml\n");
     fprintf(stderr, "   -Kkey.p12     Sign using private key in key.p12\n");

--- a/machine.h
+++ b/machine.h
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/* 
+ * Mach Operating System
+ * Copyright (c) 1989 Carnegie-Mellon University
+ * Copyright (c) 1988 Carnegie-Mellon University
+ * Copyright (c) 1987 Carnegie-Mellon University
+ * All rights reserved.  The CMU software License Agreement specifies
+ * the terms and conditions for use and redistribution.
+ */
+/*
+ * HISTORY
+ * Revision 1.1.1.1  1997/09/03 20:53:37  roland
+ * Initial checkin of SGS release 244
+ *
+ *  2 July 1992	Mac Gillon at NeXT
+ *	Changed HPPA subtypes to follow our practice. 
+ *
+ * 11 September 1992 David E. Bohman at NeXT
+ *	Added CPU_SUBTYPE_486SX to the i386 family.
+ *
+ * 16 July 1992 David E. Bohman at NeXT
+ *	Added CPU_SUBTYPE_586 to the i386 family.
+ *
+ * 17-Dec-91  Peter King (king) at NeXT
+ *	Added support for the XXX_ALL subtypes.  These are used to
+ *	tag object files that can run on any implementation of a
+ *	particular family.
+ *
+ *  1-Mar-90  John Seamons (jks) at NeXT
+ *	Redefined cpu_type and cpu_subtype definitions to indicate processor
+ *	architecture instead of product types for the MC680x0.
+ *
+ * Revision 2.15  89/10/11  14:39:56  dlb
+ * 	Removed should_exit - replaced by action thread.
+ * 	[89/01/25            dlb]
+ * 
+ * Revision 2.14  89/07/14  17:21:39  rvb
+ * 	Added CPU types and subtypes for MC68030, MC68040, MC88000,
+ * 	HPPA, ARM and Sun4-SPARC.
+ * 	[89/07/13            mrt]
+ * 
+ * Revision 2.12  89/05/30  10:38:58  rvb
+ * 	Add R2000 machine types.
+ * 	[89/05/30  08:28:53  rvb]
+ * 
+ * Revision 2.11  89/04/18  16:43:32  mwyoung
+ * 	Use <machine/vm_types.h> rather than <vm/vm_param.h> to get
+ * 	VM types.  Remove old history... none of it was insightful.
+ * 
+ * 	The variable declarations should be moved elsewhere.
+ * 	[89/01/24            mwyoung]
+ * 
+ */
+/*
+ *	Machine independent machine abstraction.
+ *	Copyright (C) 1986, Avadis Tevanian, Jr.
+ */
+
+#ifndef	_MACH_MACHINE_H_
+#define _MACH_MACHINE_H_
+
+#include <stdint.h>
+
+/*
+ *	For each host, there is a maximum possible number of
+ *	cpus that may be available in the system.  This is the
+ *	compile-time constant NCPUS, which is defined in cpus.h.
+ *
+ *	In addition, there is a machine_slot specifier for each
+ *	possible cpu in the system.
+ */
+
+typedef uint32_t	cpu_type_t;
+typedef uint32_t	cpu_subtype_t;
+typedef uint32_t	cpu_threadtype_t;
+
+/*
+ *	Machine types known by all.
+ */
+ 
+#define CPU_TYPE_ANY		((cpu_type_t) -1)
+
+#define CPU_TYPE_VAX		((cpu_type_t) 1)
+#define CPU_TYPE_ROMP		((cpu_type_t) 2)
+#define CPU_TYPE_NS32032	((cpu_type_t) 4)
+#define CPU_TYPE_NS32332        ((cpu_type_t) 5)
+#define	CPU_TYPE_MC680x0	((cpu_type_t) 6)
+#define CPU_TYPE_I386		((cpu_type_t) 7)
+#define CPU_TYPE_X86		((cpu_type_t) 7)
+#define CPU_TYPE_X86_64		((cpu_type_t) (CPU_TYPE_I386 | CPU_ARCH_ABI64))
+#define CPU_TYPE_MIPS		((cpu_type_t) 8)
+#define CPU_TYPE_NS32532        ((cpu_type_t) 9)
+#define CPU_TYPE_HPPA           ((cpu_type_t) 11)
+#define CPU_TYPE_ARM		((cpu_type_t) 12)
+#define CPU_TYPE_MC88000	((cpu_type_t) 13)
+#define CPU_TYPE_SPARC		((cpu_type_t) 14)
+#define CPU_TYPE_I860		((cpu_type_t) 15) // big-endian
+#define	CPU_TYPE_I860_LITTLE	((cpu_type_t) 16) // little-endian
+#define CPU_TYPE_RS6000		((cpu_type_t) 17)
+#define CPU_TYPE_MC98000	((cpu_type_t) 18)
+#define CPU_TYPE_POWERPC	((cpu_type_t) 18)
+#define CPU_ARCH_ABI64		 0x1000000
+#define CPU_ARCH_ABI64_32	 0x2000000
+#define CPU_ARCH_MASK        0xff000000      /* cctools-port */
+#define CPU_TYPE_POWERPC64	((cpu_type_t)(CPU_TYPE_POWERPC | CPU_ARCH_ABI64))
+#define CPU_TYPE_VEO		((cpu_type_t) 255)
+#define CPU_TYPE_ARM64		((cpu_type_t)(CPU_TYPE_ARM | CPU_ARCH_ABI64))
+#define CPU_TYPE_ARM64_32	((cpu_type_t)(CPU_TYPE_ARM | CPU_ARCH_ABI64_32))
+		
+
+/*
+ *	Machine subtypes (these are defined here, instead of in a machine
+ *	dependent directory, so that any program can get all definitions
+ *	regardless of where is it compiled).
+ */
+
+/*
+ * Capability bits used in the definition of cpu_subtype.
+ */
+#define CPU_SUBTYPE_MASK	0xff000000	/* mask for feature flags */
+#define CPU_SUBTYPE_LIB64	0x80000000	/* 64 bit libraries */
+
+/* CPU subtype capability flags for ptrauth on arm64e platforms */
+#define CPU_SUBTYPE_ARM64_PTR_AUTH_MASK 0x0f000000
+
+/* CPU subtype capability flags for ptrauth on arm64e platforms, take 2 */
+#define CPU_SUBTYPE_ARM64E_VERSIONED_ABI_MASK 0x80000000
+#define CPU_SUBTYPE_ARM64E_KERNEL_ABI_MASK 0x40000000
+#define CPU_SUBTYPE_ARM64E_PTR_AUTH_MASK 0x3f000000
+
+/*
+ *	Object files that are hand-crafted to run on any
+ *	implementation of an architecture are tagged with
+ *	CPU_SUBTYPE_MULTIPLE.  This functions essentially the same as
+ *	the "ALL" subtype of an architecture except that it allows us
+ *	to easily find object files that may need to be modified
+ *	whenever a new implementation of an architecture comes out.
+ *
+ *	It is the responsibility of the implementor to make sure the
+ *	software handles unsupported implementations elegantly.
+ */
+#define	CPU_SUBTYPE_MULTIPLE	((cpu_subtype_t) -1)
+
+
+/*
+ *	VAX subtypes (these do *not* necessary conform to the actual cpu
+ *	ID assigned by DEC available via the SID register).
+ */
+
+#define	CPU_SUBTYPE_VAX_ALL	((cpu_subtype_t) 0) 
+#define CPU_SUBTYPE_VAX780	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_VAX785	((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_VAX750	((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_VAX730	((cpu_subtype_t) 4)
+#define CPU_SUBTYPE_UVAXI	((cpu_subtype_t) 5)
+#define CPU_SUBTYPE_UVAXII	((cpu_subtype_t) 6)
+#define CPU_SUBTYPE_VAX8200	((cpu_subtype_t) 7)
+#define CPU_SUBTYPE_VAX8500	((cpu_subtype_t) 8)
+#define CPU_SUBTYPE_VAX8600	((cpu_subtype_t) 9)
+#define CPU_SUBTYPE_VAX8650	((cpu_subtype_t) 10)
+#define CPU_SUBTYPE_VAX8800	((cpu_subtype_t) 11)
+#define CPU_SUBTYPE_UVAXIII	((cpu_subtype_t) 12)
+
+/*
+ *	ROMP subtypes.
+ */
+
+#define	CPU_SUBTYPE_RT_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_RT_PC	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_RT_APC	((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_RT_135	((cpu_subtype_t) 3)
+
+/*
+ *	32032/32332/32532 subtypes.
+ */
+
+#define	CPU_SUBTYPE_MMAX_ALL	    ((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_MMAX_DPC	    ((cpu_subtype_t) 1)	/* 032 CPU */
+#define CPU_SUBTYPE_SQT		    ((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_MMAX_APC_FPU    ((cpu_subtype_t) 3)	/* 32081 FPU */
+#define CPU_SUBTYPE_MMAX_APC_FPA    ((cpu_subtype_t) 4)	/* Weitek FPA */
+#define CPU_SUBTYPE_MMAX_XPC	    ((cpu_subtype_t) 5)	/* 532 CPU */
+
+/*
+ *	I386 subtypes.
+ */
+
+#define	CPU_SUBTYPE_I386_ALL	((cpu_subtype_t) 3)
+#define	CPU_SUBTYPE_X86_64_ALL	CPU_SUBTYPE_I386_ALL
+#define CPU_SUBTYPE_386		((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_486		((cpu_subtype_t) 4)
+#define CPU_SUBTYPE_486SX	((cpu_subtype_t) 4 + 128)
+#define CPU_SUBTYPE_586		((cpu_subtype_t) 5)
+#define CPU_SUBTYPE_INTEL(f, m)	((cpu_subtype_t) (f) + ((m) << 4))
+#define CPU_SUBTYPE_PENT	CPU_SUBTYPE_INTEL(5, 0)
+#define CPU_SUBTYPE_PENTPRO	CPU_SUBTYPE_INTEL(6, 1)
+#define CPU_SUBTYPE_PENTII_M3	CPU_SUBTYPE_INTEL(6, 3)
+#define CPU_SUBTYPE_PENTII_M5	CPU_SUBTYPE_INTEL(6, 5)
+#define CPU_SUBTYPE_PENTIUM_4	CPU_SUBTYPE_INTEL(10, 0)
+
+#define CPU_SUBTYPE_INTEL_FAMILY(x)	((x) & 15)
+#define CPU_SUBTYPE_INTEL_FAMILY_MAX	15
+
+#define CPU_SUBTYPE_INTEL_MODEL(x)	((x) >> 4)
+#define CPU_SUBTYPE_INTEL_MODEL_ALL	0
+
+#define CPU_SUBTYPE_X86_64_H	((cpu_subtype_t)8) /* Haswell and compatible */
+
+/*
+ *	Mips subtypes.
+ */
+
+#define	CPU_SUBTYPE_MIPS_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_MIPS_R2300	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_MIPS_R2600	((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_MIPS_R2800	((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_MIPS_R2000a	((cpu_subtype_t) 4)
+
+/*
+ * 	680x0 subtypes
+ *
+ * The subtype definitions here are unusual for historical reasons.
+ * NeXT used to consider 68030 code as generic 68000 code.  For
+ * backwards compatability:
+ * 
+ *	CPU_SUBTYPE_MC68030 symbol has been preserved for source code
+ *	compatability.
+ *
+ *	CPU_SUBTYPE_MC680x0_ALL has been defined to be the same
+ *	subtype as CPU_SUBTYPE_MC68030 for binary comatability.
+ *
+ *	CPU_SUBTYPE_MC68030_ONLY has been added to allow new object
+ *	files to be tagged as containing 68030-specific instructions.
+ */
+
+#define	CPU_SUBTYPE_MC680x0_ALL		((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_MC68030		((cpu_subtype_t) 1) /* compat */
+#define CPU_SUBTYPE_MC68040		((cpu_subtype_t) 2) 
+#define	CPU_SUBTYPE_MC68030_ONLY	((cpu_subtype_t) 3)
+
+/*
+ *	HPPA subtypes for Hewlett-Packard HP-PA family of
+ *	risc processors. Port by NeXT to 700 series. 
+ */
+
+#define	CPU_SUBTYPE_HPPA_ALL		((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_HPPA_7100		((cpu_subtype_t) 0) /* compat */
+#define CPU_SUBTYPE_HPPA_7100LC		((cpu_subtype_t) 1)
+
+/* 
+ * 	Acorn subtypes - Acorn Risc Machine port done by
+ *		Olivetti System Software Laboratory
+ */
+
+#define	CPU_SUBTYPE_ARM_ALL		((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_ARM_A500_ARCH	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_ARM_A500		((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_ARM_A440		((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_ARM_M4		((cpu_subtype_t) 4)
+#define CPU_SUBTYPE_ARM_V4T		((cpu_subtype_t) 5)
+#define CPU_SUBTYPE_ARM_V6		((cpu_subtype_t) 6)
+#define CPU_SUBTYPE_ARM_V5TEJ		((cpu_subtype_t) 7)
+#define CPU_SUBTYPE_ARM_XSCALE		((cpu_subtype_t) 8)
+#define CPU_SUBTYPE_ARM_V7		((cpu_subtype_t) 9)
+#define CPU_SUBTYPE_ARM_V7F		((cpu_subtype_t) 10) /* Cortex A9 */
+#define CPU_SUBTYPE_ARM_V7S		((cpu_subtype_t) 11) /* Swift */
+#define CPU_SUBTYPE_ARM_V7K		((cpu_subtype_t) 12) /* Kirkwood40 */
+#define CPU_SUBTYPE_ARM_V6M		((cpu_subtype_t) 14) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V7M		((cpu_subtype_t) 15) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V7EM		((cpu_subtype_t) 16) /* Not meant to be run under xnu */
+#define CPU_SUBTYPE_ARM_V8		((cpu_subtype_t) 13)
+
+#define	CPU_SUBTYPE_ARM64_ALL		((cpu_subtype_t) 0)
+#define	CPU_SUBTYPE_ARM64_V8		((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_ARM64E		((cpu_subtype_t) 2)
+#define	CPU_SUBTYPE_ARM64_E		CPU_SUBTYPE_ARM64E /* cctools-port */
+
+#define	CPU_SUBTYPE_ARM64_32_V8		((cpu_subtype_t) 1)
+
+
+/*
+ *	MC88000 subtypes
+ */
+#define	CPU_SUBTYPE_MC88000_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_MMAX_JPC	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_MC88100	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_MC88110	((cpu_subtype_t) 2)
+
+/*
+ *	MC98000 (PowerPC) subtypes
+ */
+#define	CPU_SUBTYPE_MC98000_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_MC98601	((cpu_subtype_t) 1)
+
+/*
+ *	I860 subtypes
+ */
+#define CPU_SUBTYPE_I860_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_I860_860	((cpu_subtype_t) 1)
+
+/*
+ * 	I860 subtypes for NeXT-internal backwards compatability.
+ *	These constants will be going away.  DO NOT USE THEM!!!
+ */
+#define CPU_SUBTYPE_LITTLE_ENDIAN	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_BIG_ENDIAN		((cpu_subtype_t) 1)
+
+/*
+ *	I860_LITTLE subtypes
+ */
+#define	CPU_SUBTYPE_I860_LITTLE_ALL	((cpu_subtype_t) 0)
+#define	CPU_SUBTYPE_I860_LITTLE	((cpu_subtype_t) 1)
+
+/*
+ *	RS6000 subtypes
+ */
+#define	CPU_SUBTYPE_RS6000_ALL	((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_RS6000	((cpu_subtype_t) 1)
+
+/*
+ *	Sun4 subtypes - port done at CMU
+ */
+#define	CPU_SUBTYPE_SUN4_ALL		((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_SUN4_260		((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_SUN4_110		((cpu_subtype_t) 2)
+
+#define	CPU_SUBTYPE_SPARC_ALL		((cpu_subtype_t) 0)
+
+/*
+ *      PowerPC subtypes
+ */
+#define CPU_SUBTYPE_POWERPC_ALL		((cpu_subtype_t) 0)
+#define CPU_SUBTYPE_POWERPC_601		((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_POWERPC_602		((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_POWERPC_603		((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_POWERPC_603e	((cpu_subtype_t) 4)
+#define CPU_SUBTYPE_POWERPC_603ev	((cpu_subtype_t) 5)
+#define CPU_SUBTYPE_POWERPC_604		((cpu_subtype_t) 6)
+#define CPU_SUBTYPE_POWERPC_604e	((cpu_subtype_t) 7)
+#define CPU_SUBTYPE_POWERPC_620		((cpu_subtype_t) 8)
+#define CPU_SUBTYPE_POWERPC_750		((cpu_subtype_t) 9)
+#define CPU_SUBTYPE_POWERPC_7400	((cpu_subtype_t) 10)
+#define CPU_SUBTYPE_POWERPC_7450	((cpu_subtype_t) 11)
+#define CPU_SUBTYPE_POWERPC_970		((cpu_subtype_t) 100)
+
+/*
+ * VEO subtypes
+ * Note: the CPU_SUBTYPE_VEO_ALL will likely change over time to be defined as
+ * one of the specific subtypes.
+ */
+#define CPU_SUBTYPE_VEO_1	((cpu_subtype_t) 1)
+#define CPU_SUBTYPE_VEO_2	((cpu_subtype_t) 2)
+#define CPU_SUBTYPE_VEO_3	((cpu_subtype_t) 3)
+#define CPU_SUBTYPE_VEO_4	((cpu_subtype_t) 4)
+#define CPU_SUBTYPE_VEO_ALL	CPU_SUBTYPE_VEO_2
+
+struct archs {
+	const char *name;
+	cpu_type_t cputype;
+	cpu_subtype_t cpusubtype;
+};
+
+static const struct archs archs[] = {
+    { "any",	CPU_TYPE_ANY,	  CPU_SUBTYPE_MULTIPLE },
+    { "little",	CPU_TYPE_ANY,	  CPU_SUBTYPE_LITTLE_ENDIAN },
+    { "big",	CPU_TYPE_ANY,	  CPU_SUBTYPE_BIG_ENDIAN },
+
+/* 64-bit Mach-O architectures */
+
+    /* architecture families */
+    { "ppc64",     CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_ALL },
+    { "x86_64",    CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL },
+    { "x86_64h",   CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H },
+    { "arm64",     CPU_TYPE_ARM64,     CPU_SUBTYPE_ARM64_ALL },
+    /* specific architecture implementations */
+    { "ppc970-64", CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_970 },
+    { "arm64_32",  CPU_TYPE_ARM64_32,  CPU_SUBTYPE_ARM64_32_V8 },
+    { "arm64e",    CPU_TYPE_ARM64,  CPU_SUBTYPE_ARM64E },
+
+/* 32-bit Mach-O architectures */
+
+    /* architecture families */
+    { "ppc",    CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_ALL },
+    { "i386",   CPU_TYPE_I386,    CPU_SUBTYPE_I386_ALL },
+    { "m68k",   CPU_TYPE_MC680x0, CPU_SUBTYPE_MC680x0_ALL },
+    { "hppa",   CPU_TYPE_HPPA,    CPU_SUBTYPE_HPPA_ALL },
+    { "sparc",	CPU_TYPE_SPARC,   CPU_SUBTYPE_SPARC_ALL },
+    { "m88k",   CPU_TYPE_MC88000, CPU_SUBTYPE_MC88000_ALL },
+    { "i860",   CPU_TYPE_I860,    CPU_SUBTYPE_I860_ALL },
+    { "veo",    CPU_TYPE_VEO,     CPU_SUBTYPE_VEO_ALL },
+    { "arm",    CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_ALL },
+    /* specific architecture implementations */
+    { "ppc601", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_601 },
+    { "ppc603", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_603 },
+    { "ppc603e",CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_603e },
+    { "ppc603ev",CPU_TYPE_POWERPC,CPU_SUBTYPE_POWERPC_603ev },
+    { "ppc604", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_604 },
+    { "ppc604e",CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_604e },
+    { "ppc750", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_750 },
+    { "ppc7400",CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_7400 },
+    { "ppc7450",CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_7450 },
+    { "ppc970", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_970 },
+    { "i486",   CPU_TYPE_I386,    CPU_SUBTYPE_486 },
+    { "i486SX", CPU_TYPE_I386,    CPU_SUBTYPE_486SX },
+    { "pentium",CPU_TYPE_I386,    CPU_SUBTYPE_PENT }, /* same as i586 */
+    { "i586",   CPU_TYPE_I386,    CPU_SUBTYPE_586 },
+    { "pentpro", CPU_TYPE_I386, CPU_SUBTYPE_PENTPRO }, /* same as i686 */
+    { "i686",   CPU_TYPE_I386, CPU_SUBTYPE_PENTPRO },
+    { "pentIIm3",CPU_TYPE_I386, CPU_SUBTYPE_PENTII_M3 },
+    { "pentIIm5",CPU_TYPE_I386, CPU_SUBTYPE_PENTII_M5 },
+    { "pentium4",CPU_TYPE_I386, CPU_SUBTYPE_PENTIUM_4 },
+    { "m68030", CPU_TYPE_MC680x0, CPU_SUBTYPE_MC68030_ONLY },
+    { "m68040", CPU_TYPE_MC680x0, CPU_SUBTYPE_MC68040 },
+    { "hppa7100LC", CPU_TYPE_HPPA,  CPU_SUBTYPE_HPPA_7100LC },
+    { "veo1",   CPU_TYPE_VEO,     CPU_SUBTYPE_VEO_1 },
+    { "veo2",   CPU_TYPE_VEO,     CPU_SUBTYPE_VEO_2 },
+    { "veo3",   CPU_TYPE_VEO,     CPU_SUBTYPE_VEO_3 },
+    { "veo4",   CPU_TYPE_VEO,     CPU_SUBTYPE_VEO_4 },
+    { "armv4t", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V4T},
+    { "armv5",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V5TEJ},
+    { "xscale", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_XSCALE},
+    { "armv6",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6 },
+    { "armv6m", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V6M },
+    { "armv7",  CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7 },
+    { "armv7f", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7F },
+    { "armv7s", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7S },
+    { "armv7k", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7K },
+    { "armv7m", CPU_TYPE_ARM,     CPU_SUBTYPE_ARM_V7M },
+    { "armv7em", CPU_TYPE_ARM,    CPU_SUBTYPE_ARM_V7EM },
+    { "arm64v8",CPU_TYPE_ARM64,   CPU_SUBTYPE_ARM64_V8 },
+    { NULL,	0,		  0 }
+};
+
+#endif	/* _MACH_MACHINE_H_ */


### PR DESCRIPTION
This is identical to -A except that it uses the name of the arch not the
values of the CPU_TYPE/CPU_SUBTYPE.

This makes it more compatible with CC tools where this flag is very common.