### PR TITLE
OpenSSL 3 fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
       run: |
         export LDID_VERSION=$(echo "$(git describe --tags --abbrev=0)")
         make -j$(sysctl -n hw.ncpu) \
-          CXXFLAGS="${CXXFLAGS} -flto=thin" \
+          CXXFLAGS="-std=c++11 ${CXXFLAGS} -flto=thin" \
           VERSION="${LDID_VERSION}" \
           LIBS="${LIBPLIST_LIB} ${LIBCRYPTO_LIB}"
         strip ldid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         echo "NM=${TRIPLE}-gcc-nm" >> $GITHUB_ENV
         echo "RANLIB=${TRIPLE}-gcc-ranlib" >> $GITHUB_ENV
         echo "CFLAGS=-Os -fPIC -fno-pie -no-pie -static -flto -ffunction-sections -fdata-sections" >> $GITHUB_ENV
+        echo "CXXFLAGS=-Os -fPIC -fno-pie -no-pie -static -flto -ffunction-sections -fdata-sections" >> $GITHUB_ENV
         echo "LDFLAGS=-Wl,--gc-sections -Wl,-strip-all -flto" >> $GITHUB_ENV
 
     - name: build libplist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,7 @@ jobs:
         echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
         echo "CC=sccache clang -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
         echo "CXX=sccache clang++ -arch ${ARCH} -mmacosx-version-min=10.13" >> $GITHUB_ENV
+        echo "CXXFLAGS=-Os" >> $GITHUB_ENV
         echo "CFLAGS=-Os" >> $GITHUB_ENV
 
     - name: build libplist
@@ -189,7 +190,7 @@ jobs:
         ./configure --host=${HOST_ARCH}-apple-darwin --without-cython --enable-static --disable-shared
         make -j$(sysctl -n hw.ncpu)
 
-        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
+        echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
         echo "LIBPLIST_LIB=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
 
     - name: build openssl
@@ -200,14 +201,14 @@ jobs:
         ./config --prefix=/usr no-shared no-module darwin64-${ARCH}-cc
         make -j$(sysctl -n hw.ncpu) build_generated libcrypto.a
 
-        echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
+        echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
         echo "LIBCRYPTO_LIB=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
 
     - name: build
       run: |
         export LDID_VERSION=$(echo "$(git describe --tags --abbrev=0)")
         make -j$(sysctl -n hw.ncpu) \
-          CFLAGS="${CFLAGS} -flto=thin" \
+          CXXFLAGS="${CXXFLAGS} -flto=thin" \
           VERSION="${LDID_VERSION}" \
           LIBS="${LIBPLIST_LIB} ${LIBCRYPTO_LIB}"
         strip ldid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   LIBPLIST_VERSION: 2.2.0
-  OPENSSL_VERSION: 1.1.1n
+  OPENSSL_VERSION: 3.0.5
   SCCACHE_VERSION: 0.2.15
 
 jobs:
@@ -97,7 +97,7 @@ jobs:
         wget -q -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
         tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
         cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./Configure --prefix=/usr --static -static ${PLATFORM}
+        ./config --prefix=/usr --static -static no-module ${PLATFORM}
         make -j$(nproc) build_generated libcrypto.a
 
         echo "CPPFLAGS=${CPPFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
@@ -196,7 +196,7 @@ jobs:
         wget -q -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
         tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
         cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./Configure --prefix=/usr no-shared darwin64-${ARCH}-cc
+        ./config --prefix=/usr no-shared no-module darwin64-${ARCH}-cc
         make -j$(sysctl -n hw.ncpu) build_generated libcrypto.a
 
         echo "CFLAGS=${CFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ CXX      ?= c++
 INSTALL  ?= install
 LN       ?= ln
 
-CFLAGS   ?= -O2 -pipe
-CXXFLAGS ?= $(CFLAGS) -std=c++11
+CXXFLAGS ?= -std=c++11 -O2 -pipe
 LDFLAGS  ?=
 
 PREFIX   ?= /usr/local


### PR DESCRIPTION
- Remove deprecated openssl functions as of openssl 3.0.5
- Re-add openssl to actions with (should be) proper static providers