### PR TITLE
Implement -w flag, fix misc bugs

### DIFF
--- a/_ldid
+++ b/_ldid
@@ -2,7 +2,6 @@
 
 _arguments \
 	'-S-[Add signature]:entitlements:_files' \
- 	'-n[Do not sign recursively]' \
 	'-Q-[Embed requirements]:requirements:_files' \
 	'(-S)-r[Remove signature]' \
 	'(-r)-h[Print signature information]' \

--- a/_ldid
+++ b/_ldid
@@ -2,6 +2,7 @@
 
 _arguments \
 	'-S-[Add signature]:entitlements:_files' \
+ 	'-w[Shallow sign]' \   
 	'-Q-[Embed requirements]:requirements:_files' \
 	'(-S)-r[Remove signature]' \
 	'(-r)-h[Print signature information]' \

--- a/_ldid
+++ b/_ldid
@@ -2,6 +2,7 @@
 
 _arguments \
 	'-S-[Add signature]:entitlements:_files' \
+ 	'-n[Do not sign recursively]' \
 	'-Q-[Embed requirements]:requirements:_files' \
 	'(-S)-r[Remove signature]' \
 	'(-r)-h[Print signature information]' \

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -22,7 +22,6 @@
 .Op Fl I Ns Ar name
 .Op Fl K Ns Ar key.p12 Op Fl U Ns Ar password
 .Op Fl M
-.Op Fl n
 .Op Fl P Ns Op Ar num
 .Op Fl Q Ns Ar requirements
 .Op Fl q
@@ -110,8 +109,6 @@ merge the new and existing entitlements instead of replacing the existing
 entitlements.
 This is useful for adding a few specific entitlements to a
 handful of binaries.
-.It Fl n
-Do not sign recursively.
 .It Fl P Ns Op Ar num
 Mark the Mach-O as a platform binary.
 If

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -22,6 +22,7 @@
 .Op Fl I Ns Ar name
 .Op Fl K Ns Ar key.p12 Op Fl U Ns Ar password
 .Op Fl M
+.Op Fl n
 .Op Fl P Ns Op Ar num
 .Op Fl Q Ns Ar requirements
 .Op Fl q
@@ -109,6 +110,8 @@ merge the new and existing entitlements instead of replacing the existing
 entitlements.
 This is useful for adding a few specific entitlements to a
 handful of binaries.
+.It Fl n
+Do not sign recursively.
 .It Fl P Ns Op Ar num
 Mark the Mach-O as a platform binary.
 If

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -27,6 +27,7 @@
 .Op Fl q
 .Op Fl r | Fl S Ns Ar file.xml | Fl s
 .Op Fl u
+.Op Fl w
 .Op Fl arch Ar arch_type
 .Ar
 .Sh DESCRIPTION
@@ -142,6 +143,8 @@ This is a Procursus extension.
 .It Fl u
 If the binary was linked against UIKit, then print the UIKit version that the
 Mach-O binary was linked against.
+.It Fl w
+Shallow sign.
 .El
 .Sh EXAMPLES
 To fakesign

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -144,7 +144,17 @@ This is a Procursus extension.
 If the binary was linked against UIKit, then print the UIKit version that the
 Mach-O binary was linked against.
 .It Fl w
-Shallow sign.
+Shallow sign. Only the main binary of the specified bundle will be signed, as
+specified by
+.Ar CFBundleIdentifier
+in
+.Ar Info.plist .
+Any nested bundles and/or stray binaries will be completely
+left alone and interpreted at face-value. Applicable only when the signing
+target is a bundle directory, and not a specific Mach-O file.
+.Fl w
+can be used on any bundle, not just the root .app, including frameworks,
+appexes, and more.
 .El
 .Sh EXAMPLES
 To fakesign

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3064,7 +3064,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    if (!flag_n) {
+    if (flag_n) {
         folder.Find("", fun([&](const std::string &name) {
             if (!nested(name))
                 return;

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -1485,6 +1485,8 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
             }
         }
 
+        size = (size + 15) & ~(15);
+
         Baton baton;
         size_t alloc(allocate(mach_header, baton, size));
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -1480,6 +1480,7 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
             auto end(mach_header.Swap(symtab->stroff) + mach_header.Swap(symtab->strsize));
             if (symtab->stroff != 0 || symtab->strsize != 0) {
                 _assert(end <= size);
+                _assert(end >= size - 0x10);
                 size = end;
             }
         }

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3548,7 +3548,7 @@ int main(int argc, char *argv[]) {
             break;
 
             case 'n':
-                flag_n = true;
+                flag_n = false;
             break;
 
             case 'M':

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3074,7 +3074,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
         SubFolder subfolder(folder, bundle);
 
         State remote;
-        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
+        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, requirements, Starts(name, "PlugIns/") ? alter :
             static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
         , merge, platform, progress);
         local.Merge(bundle, remote);
@@ -3130,7 +3130,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
                     case MH_CIGAM: case MH_CIGAM_64:
                         folder.Save(name, true, flag, fun([&](std::streambuf &save) {
                             Slots slots;
-                            Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                            Sign(header.bytes, size, data, hash, save, identifier, entitlements, merge, requirements, key, slots, length, 0, platform, Progression(progress, root + name));
                         }));
                         return;
                 }

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3064,7 +3064,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    if (flag_n) {
+    if (!flag_n) {
         folder.Find("", fun([&](const std::string &name) {
             if (!nested(name))
                 return;

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -114,6 +114,7 @@
 #define _packed \
     __attribute__((packed))
 
+bool flag_U(false);
 std::string password;
 std::vector<std::string> cleanup;
 bool flag_H(false);
@@ -1823,7 +1824,7 @@ class Stuff {
             exit(1);
         }
 
-        if (!PKCS12_verify_mac(value_, "", 0) && password.empty()) {
+        if (!flag_U) {
             char passbuf[2048];
             UI_UTIL_read_pw_string(passbuf, 2048, "Enter password: ", 0);
             password = passbuf;
@@ -3546,6 +3547,7 @@ int main(int argc, char *argv[]) {
             break;
 
             case 'U':
+                flag_U = true;
                 password = argv[argi] + 2;
             break;
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -2966,7 +2966,7 @@ struct State {
     }
 };
 
-Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &parent, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     std::string executable;
     std::string identifier;
 
@@ -3061,25 +3061,23 @@ Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    if (recursively) {
-        folder.Find("", fun([&](const std::string &name) {
-            if (!nested(name))
-                return;
-            auto bundle(Split(name).dir);
-            if (mac) {
-                _assert(!bundle.empty());
-                bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
-            }
-            SubFolder subfolder(folder, bundle);
+    folder.Find("", fun([&](const std::string &name) {
+        if (!nested(name))
+            return;
+        auto bundle(Split(name).dir);
+        if (mac) {
+            _assert(!bundle.empty());
+            bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
+        }
+        SubFolder subfolder(folder, bundle);
 
-            State remote;
-            bundles[nested[1]] = Sign(root + bundle, subfolder, recursively, key, remote, "", Starts(name, "PlugIns/") ? alter :
-                static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
-            , merge, platform, progress);
-            local.Merge(bundle, remote);
-        }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
-        }));
-    }
+        State remote;
+        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
+            static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
+        , merge, platform, progress);
+        local.Merge(bundle, remote);
+    }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
+    }));
 
     std::set<std::string> excludes;
 
@@ -3105,44 +3103,42 @@ Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std
             return;
         auto &hash(local.files[name]);
 
-        if (recursively) {
-            folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
-                progress(root + name);
+        folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
+            progress(root + name);
 
-                union {
-                    struct {
-                        uint32_t magic;
-                        uint32_t count;
-                    };
+            union {
+                struct {
+                    uint32_t magic;
+                    uint32_t count;
+                };
 
-                    uint8_t bytes[8];
-                } header;
+                uint8_t bytes[8];
+            } header;
 
-                auto size(most(data, &header.bytes, sizeof(header.bytes)));
+            auto size(most(data, &header.bytes, sizeof(header.bytes)));
 
-                if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
-                    switch (Swap(header.magic)) {
-                        case FAT_MAGIC:
-                            // Java class file format
-                            if (Swap(header.count) >= 40)
-                                break;
-                        case FAT_CIGAM:
-                        case MH_MAGIC: case MH_MAGIC_64:
-                        case MH_CIGAM: case MH_CIGAM_64:
-                            folder.Save(name, true, flag, fun([&](std::streambuf &save) {
-                                Slots slots;
-                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
-                            }));
-                            return;
-                    }
+            if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
+                switch (Swap(header.magic)) {
+                    case FAT_MAGIC:
+                        // Java class file format
+                        if (Swap(header.count) >= 40)
+                            break;
+                    case FAT_CIGAM:
+                    case MH_MAGIC: case MH_MAGIC_64:
+                    case MH_CIGAM: case MH_CIGAM_64:
+                        folder.Save(name, true, flag, fun([&](std::streambuf &save) {
+                            Slots slots;
+                            Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                        }));
+                        return;
+                }
 
-                folder.Save(name, false, flag, fun([&](std::streambuf &save) {
-                    HashProxy proxy(hash, save);
-                    put(proxy, header.bytes, size);
-                    copy(data, proxy, length - size, progress);
-                }));
+            folder.Save(name, false, flag, fun([&](std::streambuf &save) {
+                HashProxy proxy(hash, save);
+                put(proxy, header.bytes, size);
+                copy(data, proxy, length - size, progress);
             }));
-        }
+        }));
     }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
         if (exclude(name))
             return;
@@ -3269,9 +3265,9 @@ Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std
     return bundle;
 }
 
-Bundle Sign(const std::string &root, Folder &folder, bool recursively, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &folder, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     State local;
-    return Sign(root, folder, recursively, key, local, requirements, alter, merge, platform, progress);
+    return Sign(root, folder, key, local, requirements, alter, merge, platform, progress);
 }
 
 #endif
@@ -3293,10 +3289,9 @@ static void usage(const char *argv0) {
     fprintf(stderr, "            host | kill | library-validation | restrict | runtime | linker-signed]] [-D] [-d]\n");
     fprintf(stderr, "            [-Enum:file] [-e] [-H[sha1 | sha256]] [-h] [-Iname]\n");
     fprintf(stderr, "            [-Kkey.p12 [-Upassword]] [-M] [-P[num]] [-Qrequirements.xml] [-q]\n");
-    fprintf(stderr, "            [-r | -Sfile.xml | -s] [-n] [-u] [-arch arch_type] file ...\n");
+    fprintf(stderr, "            [-r | -Sfile.xml | -s] [-u] [-arch arch_type] file ...\n");
     fprintf(stderr, "Common Options:\n");
     fprintf(stderr, "   -S[file.xml]  Pseudo-sign using the entitlements in file.xml\n");
-    fprintf(stderr, "   -n            Do not sign recursively\n");
     fprintf(stderr, "   -Kkey.p12     Sign using private key in key.p12\n");
     fprintf(stderr, "   -Upassword    Use password to unlock key.p12\n");
     fprintf(stderr, "   -M            Merge entitlements with any existing\n");
@@ -3334,8 +3329,6 @@ int main(int argc, char *argv[]) {
 
     bool flag_S(false);
     bool flag_s(false);
-
-    bool flag_n(true);
 
     bool flag_D(false);
     bool flag_d(false);
@@ -3548,10 +3541,6 @@ int main(int argc, char *argv[]) {
                 }
             break;
 
-            case 'n':
-                flag_n = false;
-            break;
-
             case 'M':
                 flag_M = true;
             break;
@@ -3605,7 +3594,7 @@ int main(int argc, char *argv[]) {
                 exit(1);
             }
             ldid::DiskFolder folder(path + "/");
-            path += "/" + Sign("", folder, flag_n, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
+            path += "/" + Sign("", folder, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
         } else if (flag_S || flag_r || flag_s) {
             Map input(path, O_RDONLY, PROT_READ, MAP_PRIVATE);
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3075,7 +3075,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
         SubFolder subfolder(folder, bundle);
 
         State remote;
-        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
+        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, requirements, Starts(name, "PlugIns/") ? alter :
             static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
         , merge, platform, progress, true);
         local.Merge(bundle, remote);
@@ -3132,7 +3132,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
                         if (!flag_n || !inRecursion) {
                             folder.Save(name, true, flag, fun([&](std::streambuf &save) {
                                 Slots slots;
-                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                                Sign(header.bytes, size, data, hash, save, identifier, entitlements, merge, requirements, key, slots, length, 0, platform, Progression(progress, root + name));
                             }));
                         }
                         return;

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -1480,7 +1480,6 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
             auto end(mach_header.Swap(symtab->stroff) + mach_header.Swap(symtab->strsize));
             if (symtab->stroff != 0 || symtab->strsize != 0) {
                 _assert(end <= size);
-                _assert(end >= size - 0x10);
                 size = end;
             }
         }

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3548,7 +3548,7 @@ int main(int argc, char *argv[]) {
             break;
 
             case 'n':
-                flag_n = false;
+                flag_n = true;
             break;
 
             case 'M':

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -3075,7 +3075,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
         SubFolder subfolder(folder, bundle);
 
         State remote;
-        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, requirements, Starts(name, "PlugIns/") ? alter :
+        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
             static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
         , merge, platform, progress, true);
         local.Merge(bundle, remote);
@@ -3132,7 +3132,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
                         if (!flag_n || !inRecursion) {
                             folder.Save(name, true, flag, fun([&](std::streambuf &save) {
                                 Slots slots;
-                                Sign(header.bytes, size, data, hash, save, identifier, entitlements, merge, requirements, key, slots, length, 0, platform, Progression(progress, root + name));
+                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
                             }));
                         }
                         return;

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -1485,8 +1485,6 @@ static void Allocate(const void *idata, size_t isize, std::streambuf &output, co
             }
         }
 
-        size = (size + 15) & ~(15);
-
         Baton baton;
         size_t alloc(allocate(mach_header, baton, size));
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -2966,7 +2966,7 @@ struct State {
     }
 };
 
-Bundle Sign(const std::string &root, Folder &parent, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     std::string executable;
     std::string identifier;
 
@@ -3061,23 +3061,25 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    folder.Find("", fun([&](const std::string &name) {
-        if (!nested(name))
-            return;
-        auto bundle(Split(name).dir);
-        if (mac) {
-            _assert(!bundle.empty());
-            bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
-        }
-        SubFolder subfolder(folder, bundle);
+    if (recursively) {
+        folder.Find("", fun([&](const std::string &name) {
+            if (!nested(name))
+                return;
+            auto bundle(Split(name).dir);
+            if (mac) {
+                _assert(!bundle.empty());
+                bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
+            }
+            SubFolder subfolder(folder, bundle);
 
-        State remote;
-        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
-            static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
-        , merge, platform, progress);
-        local.Merge(bundle, remote);
-    }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
-    }));
+            State remote;
+            bundles[nested[1]] = Sign(root + bundle, subfolder, recursively, key, remote, "", Starts(name, "PlugIns/") ? alter :
+                static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
+            , merge, platform, progress);
+            local.Merge(bundle, remote);
+        }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
+        }));
+    }
 
     std::set<std::string> excludes;
 
@@ -3103,42 +3105,44 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
             return;
         auto &hash(local.files[name]);
 
-        folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
-            progress(root + name);
+        if (recursively) {
+            folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
+                progress(root + name);
 
-            union {
-                struct {
-                    uint32_t magic;
-                    uint32_t count;
-                };
+                union {
+                    struct {
+                        uint32_t magic;
+                        uint32_t count;
+                    };
 
-                uint8_t bytes[8];
-            } header;
+                    uint8_t bytes[8];
+                } header;
 
-            auto size(most(data, &header.bytes, sizeof(header.bytes)));
+                auto size(most(data, &header.bytes, sizeof(header.bytes)));
 
-            if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
-                switch (Swap(header.magic)) {
-                    case FAT_MAGIC:
-                        // Java class file format
-                        if (Swap(header.count) >= 40)
-                            break;
-                    case FAT_CIGAM:
-                    case MH_MAGIC: case MH_MAGIC_64:
-                    case MH_CIGAM: case MH_CIGAM_64:
-                        folder.Save(name, true, flag, fun([&](std::streambuf &save) {
-                            Slots slots;
-                            Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
-                        }));
-                        return;
-                }
+                if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
+                    switch (Swap(header.magic)) {
+                        case FAT_MAGIC:
+                            // Java class file format
+                            if (Swap(header.count) >= 40)
+                                break;
+                        case FAT_CIGAM:
+                        case MH_MAGIC: case MH_MAGIC_64:
+                        case MH_CIGAM: case MH_CIGAM_64:
+                            folder.Save(name, true, flag, fun([&](std::streambuf &save) {
+                                Slots slots;
+                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                            }));
+                            return;
+                    }
 
-            folder.Save(name, false, flag, fun([&](std::streambuf &save) {
-                HashProxy proxy(hash, save);
-                put(proxy, header.bytes, size);
-                copy(data, proxy, length - size, progress);
+                folder.Save(name, false, flag, fun([&](std::streambuf &save) {
+                    HashProxy proxy(hash, save);
+                    put(proxy, header.bytes, size);
+                    copy(data, proxy, length - size, progress);
+                }));
             }));
-        }));
+        }
     }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
         if (exclude(name))
             return;
@@ -3265,9 +3269,9 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     return bundle;
 }
 
-Bundle Sign(const std::string &root, Folder &folder, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &folder, bool recursively, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     State local;
-    return Sign(root, folder, key, local, requirements, alter, merge, platform, progress);
+    return Sign(root, folder, recursively, key, local, requirements, alter, merge, platform, progress);
 }
 
 #endif
@@ -3289,9 +3293,10 @@ static void usage(const char *argv0) {
     fprintf(stderr, "            host | kill | library-validation | restrict | runtime | linker-signed]] [-D] [-d]\n");
     fprintf(stderr, "            [-Enum:file] [-e] [-H[sha1 | sha256]] [-h] [-Iname]\n");
     fprintf(stderr, "            [-Kkey.p12 [-Upassword]] [-M] [-P[num]] [-Qrequirements.xml] [-q]\n");
-    fprintf(stderr, "            [-r | -Sfile.xml | -s] [-u] [-arch arch_type] file ...\n");
+    fprintf(stderr, "            [-r | -Sfile.xml | -s] [-n] [-u] [-arch arch_type] file ...\n");
     fprintf(stderr, "Common Options:\n");
     fprintf(stderr, "   -S[file.xml]  Pseudo-sign using the entitlements in file.xml\n");
+    fprintf(stderr, "   -n            Do not sign recursively\n");
     fprintf(stderr, "   -Kkey.p12     Sign using private key in key.p12\n");
     fprintf(stderr, "   -Upassword    Use password to unlock key.p12\n");
     fprintf(stderr, "   -M            Merge entitlements with any existing\n");
@@ -3329,6 +3334,8 @@ int main(int argc, char *argv[]) {
 
     bool flag_S(false);
     bool flag_s(false);
+
+    bool flag_n(true);
 
     bool flag_D(false);
     bool flag_d(false);
@@ -3541,6 +3548,10 @@ int main(int argc, char *argv[]) {
                 }
             break;
 
+            case 'n':
+                flag_n = false;
+            break;
+
             case 'M':
                 flag_M = true;
             break;
@@ -3594,7 +3605,7 @@ int main(int argc, char *argv[]) {
                 exit(1);
             }
             ldid::DiskFolder folder(path + "/");
-            path += "/" + Sign("", folder, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
+            path += "/" + Sign("", folder, flag_n, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
         } else if (flag_S || flag_r || flag_s) {
             Map input(path, O_RDONLY, PROT_READ, MAP_PRIVATE);
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -115,7 +115,6 @@
     __attribute__((packed))
 
 std::string password;
-bool flag_U(false);
 std::vector<std::string> cleanup;
 bool flag_H(false);
 
@@ -1824,7 +1823,7 @@ class Stuff {
             exit(1);
         }
 
-        if (!flag_U) {
+        if (!PKCS12_verify_mac(value_, "", 0) && password.empty()) {
             char passbuf[2048];
             UI_UTIL_read_pw_string(passbuf, 2048, "Enter password: ", 0);
             password = passbuf;
@@ -3558,7 +3557,6 @@ int main(int argc, char *argv[]) {
             break;
 
             case 'U':
-                flag_U = true;
                 password = argv[argi] + 2;
             break;
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -2969,7 +2969,7 @@ struct State {
     }
 };
 
-Bundle Sign(const std::string &root, Folder &parent, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &parent, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress, bool inRecursion) {
     std::string executable;
     std::string identifier;
 
@@ -3064,25 +3064,23 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    if (!flag_n) {
-        folder.Find("", fun([&](const std::string &name) {
-            if (!nested(name))
-                return;
-            auto bundle(Split(name).dir);
-            if (mac) {
-                _assert(!bundle.empty());
-                bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
-            }
-            SubFolder subfolder(folder, bundle);
+    folder.Find("", fun([&](const std::string &name) {
+        if (!nested(name))
+            return;
+        auto bundle(Split(name).dir);
+        if (mac) {
+            _assert(!bundle.empty());
+            bundle = Split(bundle.substr(0, bundle.size() - 1)).dir;
+        }
+        SubFolder subfolder(folder, bundle);
 
-            State remote;
-            bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
-                static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
-            , merge, platform, progress);
-            local.Merge(bundle, remote);
-        }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
-        }));
-    }
+        State remote;
+        bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
+            static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
+        , merge, platform, progress, true);
+        local.Merge(bundle, remote);
+    }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
+    }));
 
     std::set<std::string> excludes;
 
@@ -3131,10 +3129,12 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
                     case FAT_CIGAM:
                     case MH_MAGIC: case MH_MAGIC_64:
                     case MH_CIGAM: case MH_CIGAM_64:
-                        folder.Save(name, true, flag, fun([&](std::streambuf &save) {
-                            Slots slots;
-                            Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
-                        }));
+                        if (!flag_n || !inRecursion) {
+                            folder.Save(name, true, flag, fun([&](std::streambuf &save) {
+                                Slots slots;
+                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                            }));
+                        }
                         return;
                 }
 
@@ -3259,12 +3259,14 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
 
     folder.Open(executable, fun([&](std::streambuf &buffer, size_t length, const void *flag) {
         progress(root + executable);
-        folder.Save(executable, true, flag, fun([&](std::streambuf &save) {
-            Slots slots;
-            slots[1] = local.files.at(info);
-            slots[3] = local.files.at(signature);
-            bundle.hash = Sign(NULL, 0, buffer, local.files[executable], save, identifier, entitlements, merge, requirements, key, slots, length, 0, platform, Progression(progress, root + executable));
-        }));
+        if (!flag_n || !inRecursion) {
+            folder.Save(executable, true, flag, fun([&](std::streambuf &save) {
+                Slots slots;
+                slots[1] = local.files.at(info);
+                slots[3] = local.files.at(signature);
+                bundle.hash = Sign(NULL, 0, buffer, local.files[executable], save, identifier, entitlements, merge, requirements, key, slots, length, 0, platform, Progression(progress, root + executable));
+            }));
+        }
     }));
 
     return bundle;
@@ -3272,7 +3274,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
 
 Bundle Sign(const std::string &root, Folder &folder, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     State local;
-    return Sign(root, folder, key, local, requirements, alter, merge, platform, progress);
+    return Sign(root, folder, key, local, requirements, alter, merge, platform, progress, false);
 }
 
 #endif

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -118,7 +118,6 @@ std::string password;
 bool flag_U(false);
 std::vector<std::string> cleanup;
 bool flag_H(false);
-bool flag_n(false);
 
 template <typename Type_>
 struct Iterator_ {
@@ -2969,7 +2968,7 @@ struct State {
     }
 };
 
-Bundle Sign(const std::string &root, Folder &parent, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &parent, bool recursively, const std::string &key, State &local, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     std::string executable;
     std::string identifier;
 
@@ -3064,7 +3063,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     Expression nested("^(Frameworks/[^/]*\\.framework|PlugIns/[^/]*\\.appex(()|/[^/]*.app))/(" + failure + ")Info\\.plist$");
     std::map<std::string, Bundle> bundles;
 
-    if (flag_n) {
+    if (recursively) {
         folder.Find("", fun([&](const std::string &name) {
             if (!nested(name))
                 return;
@@ -3076,7 +3075,7 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
             SubFolder subfolder(folder, bundle);
 
             State remote;
-            bundles[nested[1]] = Sign(root + bundle, subfolder, key, remote, "", Starts(name, "PlugIns/") ? alter :
+            bundles[nested[1]] = Sign(root + bundle, subfolder, recursively, key, remote, "", Starts(name, "PlugIns/") ? alter :
                 static_cast<const Functor<std::string (const std::string &, const std::string &)> &>(fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }))
             , merge, platform, progress);
             local.Merge(bundle, remote);
@@ -3108,42 +3107,44 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
             return;
         auto &hash(local.files[name]);
 
-        folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
-            progress(root + name);
+        if (recursively) {
+            folder.Open(name, fun([&](std::streambuf &data, size_t length, const void *flag) {
+                progress(root + name);
 
-            union {
-                struct {
-                    uint32_t magic;
-                    uint32_t count;
-                };
+                union {
+                    struct {
+                        uint32_t magic;
+                        uint32_t count;
+                    };
 
-                uint8_t bytes[8];
-            } header;
+                    uint8_t bytes[8];
+                } header;
 
-            auto size(most(data, &header.bytes, sizeof(header.bytes)));
+                auto size(most(data, &header.bytes, sizeof(header.bytes)));
 
-            if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
-                switch (Swap(header.magic)) {
-                    case FAT_MAGIC:
-                        // Java class file format
-                        if (Swap(header.count) >= 40)
-                            break;
-                    case FAT_CIGAM:
-                    case MH_MAGIC: case MH_MAGIC_64:
-                    case MH_CIGAM: case MH_CIGAM_64:
-                        folder.Save(name, true, flag, fun([&](std::streambuf &save) {
-                            Slots slots;
-                            Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
-                        }));
-                        return;
-                }
+                if (name != "_WatchKitStub/WK" && size == sizeof(header.bytes))
+                    switch (Swap(header.magic)) {
+                        case FAT_MAGIC:
+                            // Java class file format
+                            if (Swap(header.count) >= 40)
+                                break;
+                        case FAT_CIGAM:
+                        case MH_MAGIC: case MH_MAGIC_64:
+                        case MH_CIGAM: case MH_CIGAM_64:
+                            folder.Save(name, true, flag, fun([&](std::streambuf &save) {
+                                Slots slots;
+                                Sign(header.bytes, size, data, hash, save, identifier, "", false, "", key, slots, length, 0, platform, Progression(progress, root + name));
+                            }));
+                            return;
+                    }
 
-            folder.Save(name, false, flag, fun([&](std::streambuf &save) {
-                HashProxy proxy(hash, save);
-                put(proxy, header.bytes, size);
-                copy(data, proxy, length - size, progress);
+                folder.Save(name, false, flag, fun([&](std::streambuf &save) {
+                    HashProxy proxy(hash, save);
+                    put(proxy, header.bytes, size);
+                    copy(data, proxy, length - size, progress);
+                }));
             }));
-        }));
+        }
     }), fun([&](const std::string &name, const Functor<std::string ()> &read) {
         if (exclude(name))
             return;
@@ -3270,9 +3271,9 @@ Bundle Sign(const std::string &root, Folder &parent, const std::string &key, Sta
     return bundle;
 }
 
-Bundle Sign(const std::string &root, Folder &folder, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
+Bundle Sign(const std::string &root, Folder &folder, bool recursively, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress) {
     State local;
-    return Sign(root, folder, key, local, requirements, alter, merge, platform, progress);
+    return Sign(root, folder, recursively, key, local, requirements, alter, merge, platform, progress);
 }
 
 #endif
@@ -3335,6 +3336,8 @@ int main(int argc, char *argv[]) {
 
     bool flag_S(false);
     bool flag_s(false);
+
+    bool flag_n(true);
 
     bool flag_D(false);
     bool flag_d(false);
@@ -3605,7 +3608,7 @@ int main(int argc, char *argv[]) {
                 exit(1);
             }
             ldid::DiskFolder folder(path + "/");
-            path += "/" + Sign("", folder, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
+            path += "/" + Sign("", folder, flag_n, key, requirements, ldid::fun([&](const std::string &, const std::string &) -> std::string { return entitlements; }), flag_M, platform, dummy_).path;
         } else if (flag_S || flag_r || flag_s) {
             Map input(path, O_RDONLY, PROT_READ, MAP_PRIVATE);
 

--- a/ldid.cpp
+++ b/ldid.cpp
@@ -115,6 +115,7 @@
     __attribute__((packed))
 
 std::string password;
+bool flag_U(false);
 std::vector<std::string> cleanup;
 bool flag_H(false);
 
@@ -1823,7 +1824,7 @@ class Stuff {
             exit(1);
         }
 
-        if (!PKCS12_verify_mac(value_, "", 0) && password.empty()) {
+        if (!flag_U) {
             char passbuf[2048];
             UI_UTIL_read_pw_string(passbuf, 2048, "Enter password: ", 0);
             password = passbuf;
@@ -3557,6 +3558,7 @@ int main(int argc, char *argv[]) {
             break;
 
             case 'U':
+                flag_U = true;
                 password = argv[argi] + 2;
             break;
 


### PR DESCRIPTION
Changes: 

- Implements the `-w` flag, which will perform a shallow sign. Only the main binary of the specified bundle will be signed, as specified by `CFBundleIdentifier` in `Info.plist`. Any nested bundles and/or stray binaries will be completely left alone and interpreted at face-value. Applicable only when the signing target is a bundle directory, and not a specific Mach-O file. `-w` can be used on any bundle, not just the root .app, including frameworks, appexes, and more. This is supposed to mimic the behavior of Apple's `codesign` tool. I know this is probably confusing, so at the bottom of this PR, I explain a real-world example of when `-w` can help. I did add `-w` to the manual entry....but only for the English version. The zh_CN and zh_TW versions will need to be updated separately, which I presume is a question for @asdfugil?

- Fixes `-U` support for blank passwords. Previously, if you specified `-U` along with a .p12 that doesn't have a password, you would still be prompted to enter the password. This PR fixes that. 

- Fixes an alignment issue with `LC_CODE_SIGNATURE`. Previously, ldid aligned to a multiple of 8 bytes, but modern Apple platforms use a multiple of 16 bytes. This PR fixes that. 

- Removes one particular `_assert()` that seems to be preventing legitimate cases. I'm not entirely sure why this assert() exists to begin with....but I ran some tests without it....and everything still seems to work as intended. In any case, during my tests, it was indeed preventing legitimate cases. ¯\_(ツ)_/¯

- Forwards the user's choice of entitlements/requirements to nested bundles/stray binaries. Previously, when ldid signed nested bundles, it didn't forward the user's choice of requirements. It also didn't forward both entitlements and requirements when signing stray binaries. In some edge cases, this resulted in improperly entitled binaries. This PR fixes that. This should also resolve issue #24 reported by @opa334. 

Lastly, a real-world example for when `-w` can help. Let's say you want to sign an app that has 3 Mach-O binaries: the main binary, an appex, and a framework. Let's also say that the main binary expects Entitlement A, the appex expects Entitlement B, and the framework expects no entitlements. Let's try to sign the app with existing ldid: 
```sh
ldid -SEntitlements-all.plist Example.app
```
Uh oh. It signed all 3 binaries with the same entitlements, which is not what we want. Let's try again, this time introducing `-w`: 
```sh
ldid -w -S Example.app/Frameworks/Something.framework
ldid -w -SEntitlements-B.plist Example.app/PlugIns/MessagesExtension.appex
ldid -w -SEntitlements-A.plist Example.app
```
Great! Now all 3 binaries have the correct entitlements that each of them expects. 

Now, I know what you're thinking: "But can't you accomplish the same thing by signing each bundle in bottom-up order?"
Answer: Not really, no. Let's you sign the .appex first, and then sign the root .app. At the .app stage, ldid will go back and resign the appex....overwriting your entitlements and undoing what you did. 

Apple's `codesign` tool operates in a similar way to `-w`, so `-w` tries to mimic that. When Xcode compiles a project, it individually codesigns each binary - it does not do a single codesign at the root .app, due to the same problem that I'm describing: different binaries potentially need different entitlements. 