### PR TITLE
Migrate to Node16-based Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '*.c'
       - '*.cpp'
-      - 'Maiefile'
+      - 'Makefile'
       - '.github/workflows/*'
   pull_request:
     paths:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,16 +168,13 @@ jobs:
           name: ldid_${{ env.OS }}_${{ env.ARCH }}
           path: ldid${{ env.EXT }}
 
-      - name: Upload Release Asset Linux/Windows
-        uses: actions/upload-release-asset@v1
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
         if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ldid${{ env.EXT }}
-          asset_name: ldid_${{ env.OS }}_${{ env.ARCH }}${{ env.EXT }}
-          asset_content_type: application/octet-stream
+          files: ldid${{ env.EXT }}
 
   build-macos:
     name: Build
@@ -282,13 +279,10 @@ jobs:
           name: ldid_${{ matrix.os }}_${{ matrix.arch }}
           path: ldid
 
-      - name: Upload Release Asset macOS
-        uses: actions/upload-release-asset@v1
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
         if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ldid
-          asset_name: ldid_${{ matrix.os }}_${{ matrix.arch }}
-          asset_content_type: application/octet-stream
+          files: ldid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   push:
@@ -49,7 +49,7 @@ jobs:
           path: |
             ~/.cache/sccache
             ~/dep_src
-          key: build-linux-${{ matrix.triple }}-${{ env.GITHUB_SHA }}
+          key: build-linux-${{ matrix.triple }}-${{ github.sha }}
           restore-keys: |
             build-linux-${{ matrix.triple }}-
 
@@ -204,7 +204,7 @@ jobs:
           path: |
             ~/Library/Caches/Mozilla.sccache
             ~/dep_src
-          key: build-${{ matrix.os }}-${{ matrix.arch }}-${ { env.GITHUB_SHA } }
+          key: build-${{ matrix.os }}-${{ matrix.arch }}-${{ github.sha }}
           restore-keys: |
             build-${{ matrix.os }}-${{ matrix.arch }}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build-linux:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         triple:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
-      - name: Cache dependencies
+      - name: Restore or cache dependencies
         uses: actions/cache@v3
         with:
           path: |
@@ -195,8 +193,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Restore or cache dependencies
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,18 @@
-name: build
+name: Build
+
 on:
   push:
     paths:
       - '*.c'
       - '*.cpp'
+      - 'Maiefile'
       - '.github/workflows/*'
-      - 'Makefile'
   pull_request:
     paths:
       - '*.c'
       - '*.cpp'
-      - '.github/workflows/*'
       - 'Makefile'
+      - '.github/workflows/*'
   workflow_dispatch:
   release:
     types:
@@ -24,6 +25,7 @@ env:
 
 jobs:
   build-linux:
+    name: Build
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -36,149 +38,149 @@ jobs:
       TRIPLE: ${{ matrix.triple }}
 
     steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/sccache
-          ~/dep_src
-        key: build-linux-${{ matrix.triple }}-${{ env.GITHUB_SHA }}
-        restore-keys: |
-          build-linux-${{ matrix.triple }}-
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/sccache
+            ~/dep_src
+          key: build-linux-${{ matrix.triple }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            build-linux-${{ matrix.triple }}-
 
-    - name: setup environment
-      run: |
-        export DOWNLOAD_PATH=${HOME}/dep_src
-        export DEP_PATH=${HOME}/build
-        mkdir -p ${DOWNLOAD_PATH} ${DEP_PATH}
-        echo "DOWNLOAD_PATH=${DOWNLOAD_PATH}" >> $GITHUB_ENV
-        echo "DEP_PATH=${DEP_PATH}" >> $GITHUB_ENV
-        echo "ARCH=$(echo ${{ matrix.triple }} | cut -d- -f 1)" >> $GITHUB_ENV
-        echo "OS=$(echo ${{ matrix.triple }} | cut -d- -f 2)" >> $GITHUB_ENV
-        if [ "$(echo ${{ matrix.triple }} | cut -d- -f 2)" = "w64" ]; then
-          echo "EXT=.exe" >> $GITHUB_ENV
-        else
-          echo "EXT=" >> $GITHUB_ENV
-        fi
+      - name: Setup environment
+        run: |
+          export DOWNLOAD_PATH=${HOME}/dep_src
+          export DEP_PATH=${HOME}/build
+          mkdir -p ${DOWNLOAD_PATH} ${DEP_PATH}
+          echo "DOWNLOAD_PATH=${DOWNLOAD_PATH}" >> $GITHUB_ENV
+          echo "DEP_PATH=${DEP_PATH}" >> $GITHUB_ENV
+          echo "ARCH=$(echo ${{ matrix.triple }} | cut -d- -f 1)" >> $GITHUB_ENV
+          echo "OS=$(echo ${{ matrix.triple }} | cut -d- -f 2)" >> $GITHUB_ENV
+          if [ "$(echo ${{ matrix.triple }} | cut -d- -f 2)" = "w64" ]; then
+            echo "EXT=.exe" >> $GITHUB_ENV
+          else
+            echo "EXT=" >> $GITHUB_ENV
+          fi
 
-    - name: setup toolchain
-      run: |
-        # Download Toolchain
-        wget -nc -P ${DOWNLOAD_PATH} https://cameronkatri.com/toolchains/${TOOLCHAIN}.tgz
-        tar xf ${DOWNLOAD_PATH}/${TOOLCHAIN}.tgz -C ${HOME}
+      - name: Setup toolchain
+        run: |
+          wget -nc -P ${DOWNLOAD_PATH} https://cameronkatri.com/toolchains/${TOOLCHAIN}.tgz
+          wget -nc -P ${DOWNLOAD_PATH} https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+          tar xf ${DOWNLOAD_PATH}/${TOOLCHAIN}.tgz -C ${HOME}
+          tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz -C ${HOME}
+          mv ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache ${HOME}/${TOOLCHAIN}/bin
+          chmod +x ${HOME}/${TOOLCHAIN}/bin/sccache
 
-        # Download sccache
-        wget -nc -P ${DOWNLOAD_PATH} \
-          https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-        tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz -C ${HOME}
-        mv ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache ${HOME}/${TOOLCHAIN}/bin
-        chmod +x ${HOME}/${TOOLCHAIN}/bin/sccache
+          echo "${HOME}/${TOOLCHAIN}/bin" >> $GITHUB_PATH
+          echo "CC=sccache ${TRIPLE}-gcc" >> $GITHUB_ENV
+          echo "CXX=sccache ${TRIPLE}-g++" >> $GITHUB_ENV
+          echo "AR=${TRIPLE}-gcc-ar" >> $GITHUB_ENV
+          echo "NM=${TRIPLE}-gcc-nm" >> $GITHUB_ENV
+          echo "RANLIB=${TRIPLE}-gcc-ranlib" >> $GITHUB_ENV
+          if [ "${OS}" = "w64" ]; then
+            echo "CFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -fdata-sections" >> $GITHUB_ENV
+            echo "CXXFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -fdata-sections" >> $GITHUB_ENV
+            echo "LDFLAGS=-Os -fPIC -fno-pie -no-pie -static -Wl,--gc-sections -Wl,-strip-all -ffunction-sections -fdata-sections" >> $GITHUB_ENV
+          else
+            echo "CFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -flto -fdata-sections" >> $GITHUB_ENV
+            echo "CXXFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -flto -fdata-sections" >> $GITHUB_ENV
+            echo "LDFLAGS=-Os -fPIC -fno-pie -no-pie -static -Wl,--gc-sections -Wl,-strip-all -flto -ffunction-sections -fdata-sections" >> $GITHUB_ENV
+          fi
 
-        echo "${HOME}/${TOOLCHAIN}/bin" >> $GITHUB_PATH
-        echo "CC=sccache ${TRIPLE}-gcc" >> $GITHUB_ENV
-        echo "CXX=sccache ${TRIPLE}-g++" >> $GITHUB_ENV
-        echo "AR=${TRIPLE}-gcc-ar" >> $GITHUB_ENV
-        echo "NM=${TRIPLE}-gcc-nm" >> $GITHUB_ENV
-        echo "RANLIB=${TRIPLE}-gcc-ranlib" >> $GITHUB_ENV
-        if [ "${OS}" = "w64" ]; then
-        echo "CFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -fdata-sections" >> $GITHUB_ENV
-        echo "CXXFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -fdata-sections" >> $GITHUB_ENV
-        echo "LDFLAGS=-Os -fPIC -fno-pie -no-pie -static -Wl,--gc-sections -Wl,-strip-all -ffunction-sections -fdata-sections" >> $GITHUB_ENV
-        else
-        echo "CFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -flto -fdata-sections" >> $GITHUB_ENV
-        echo "CXXFLAGS=-Os -fPIC -fno-pie -no-pie -static -ffunction-sections -flto -fdata-sections" >> $GITHUB_ENV
-        echo "LDFLAGS=-Os -fPIC -fno-pie -no-pie -static -Wl,--gc-sections -Wl,-strip-all -flto -ffunction-sections -fdata-sections" >> $GITHUB_ENV
-        fi
+      - name: Build libplist
+        run: |
+          wget -nc -P ${DOWNLOAD_PATH} https://github.com/libimobiledevice/libplist/releases/download/${LIBPLIST_VERSION}/libplist-${LIBPLIST_VERSION}.tar.bz2
+          tar xf ${DOWNLOAD_PATH}/libplist-${LIBPLIST_VERSION}.tar.bz2 -C ${DEP_PATH}
+          cd ${DEP_PATH}/libplist-${LIBPLIST_VERSION}
+          ./configure --host=${TRIPLE} --prefix=/usr --without-cython --enable-static --disable-shared
+          make -j$(nproc)
 
-    - name: build libplist
-      run: |
-        wget -nc -P ${DOWNLOAD_PATH} https://github.com/libimobiledevice/libplist/releases/download/${LIBPLIST_VERSION}/libplist-${LIBPLIST_VERSION}.tar.bz2
-        tar xf ${DOWNLOAD_PATH}/libplist-${LIBPLIST_VERSION}.tar.bz2 -C ${DEP_PATH}
-        cd ${DEP_PATH}/libplist-${LIBPLIST_VERSION}
-        ./configure --host=${TRIPLE} --prefix=/usr --without-cython --enable-static --disable-shared
-        make -j$(nproc)
+          echo "LIBPLIST_INCLUDES=-I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
+          echo "LIBPLIST_LIBS=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
 
-        echo "LIBPLIST_INCLUDES=-I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
-        echo "LIBPLIST_LIBS=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
+      - name: Build OpenSSL
+        run: |
+          if [ "${OS}" = "w64" ]; then
+            export PLATFORM="mingw64"
+          else
+            export PLATFORM="linux-${ARCH}"
+          fi
 
-    - name: build openssl
-      run: |
-        if [ "${OS}" = "w64" ]; then
-          export PLATFORM="mingw64"
-        else
-          export PLATFORM="linux-${ARCH}"
-        fi
+          wget -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+          tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
+          cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
+          ./config -static enable-fips enable-capieng no-module enable-ktls no-zlib \
+            no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m no-sm2 no-sm4 no-ssl3 no-seed no-weak-ssl-ciphers ${PLATFORM}
+          make -j$(nproc) build_generated libcrypto.a
 
-        wget -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-        tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
-        cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./config -static enable-fips enable-capieng no-module enable-ktls no-zlib \
-               no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m no-sm2 no-sm4 no-ssl3 no-seed no-weak-ssl-ciphers ${PLATFORM}
-        make -j$(nproc) build_generated libcrypto.a
+          echo "LIBCRYPTO_INCLUDES=-I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
+          if [ "${OS}" = "w64" ]; then
+            echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a -lws2_32 -lgdi32 -ladvapi32 -lcrypt32 -luser32" >> $GITHUB_ENV
+          else
+            echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
+          fi
 
-        echo "LIBCRYPTO_INCLUDES=-I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
-        if [ "${OS}" = "w64" ]; then
-          echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a -lws2_32 -lgdi32 -ladvapi32 -lcrypt32 -luser32" >> $GITHUB_ENV
-        else
-          echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
-        fi
+      - name: Build mman-win32
+        if: ${{ env.OS == 'w64' }}
+        run: |
+          wget -nc -O ${DOWNLOAD_PATH}/mman-win32.tar.gz https://github.com/alitrack/mman-win32/archive/refs/heads/master.tar.gz || true
+          tar xf ${DOWNLOAD_PATH}/mman-win32.tar.gz -C ${DEP_PATH}
+          cd ${DEP_PATH}/mman-win32-master
+          ./configure --prefix=/ --disable-shared --enable-static --cross-prefix="${TRIPLE}-"
+          make -j$(nproc)
+          mkdir -p include/sys/
+          ln -s ../../mman.h include/sys/
 
-    - name: build mman-win32
-      if: ${{ env.OS == 'w64' }}
-      run: |
-        wget -nc -O ${DOWNLOAD_PATH}/mman-win32.tar.gz https://github.com/alitrack/mman-win32/archive/refs/heads/master.tar.gz || true
-        tar xf ${DOWNLOAD_PATH}/mman-win32.tar.gz -C ${DEP_PATH}
-        cd ${DEP_PATH}/mman-win32-master
-        ./configure --prefix=/ --disable-shared --enable-static --cross-prefix="${TRIPLE}-"
-        make -j$(nproc)
-        mkdir -p include/sys/
-        ln -s ../../mman.h include/sys/
+          echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/mman-win32-master/include" >> $GITHUB_ENV
+          echo "LIBS=${LIBS} ${DEP_PATH}/mman-win32-master/libmman.a" >> $GITHUB_ENV
 
-        echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/mman-win32-master/include" >> $GITHUB_ENV
-        echo "LIBS=${LIBS} ${DEP_PATH}/mman-win32-master/libmman.a" >> $GITHUB_ENV
+      - name: Build tre
+        if: ${{ env.OS == 'w64' }}
+        run: |
+          sudo apt-get install -y autopoint
+          wget -nc -O ${DOWNLOAD_PATH}/tre.tar.gz https://github.com/laurikari/tre/archive/refs/heads/master.tar.gz || true
+          tar xf ${DOWNLOAD_PATH}/tre.tar.gz -C ${DEP_PATH}
+          cd ${DEP_PATH}/tre-master
+          ./utils/autogen.sh
+          ./configure --host=${TRIPLE} --prefix=/usr --without-cython --enable-static --disable-shared
+          make -j$(nproc)
 
-    - name: build tre
-      if: ${{ env.OS == 'w64' }}
-      run: |
-        sudo apt-get install -y autopoint
-        wget -nc -O ${DOWNLOAD_PATH}/tre.tar.gz https://github.com/laurikari/tre/archive/refs/heads/master.tar.gz || true
-        tar xf ${DOWNLOAD_PATH}/tre.tar.gz -C ${DEP_PATH}
-        cd ${DEP_PATH}/tre-master
-        ./utils/autogen.sh
-        ./configure --host=${TRIPLE} --prefix=/usr --without-cython --enable-static --disable-shared
-        make -j$(nproc)
+          echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/tre-master/lib" >> $GITHUB_ENV
+          echo "LIBS=${LIBS} ${DEP_PATH}/tre-master/lib/.libs/libtre.a" >> $GITHUB_ENV
 
-        echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/tre-master/lib" >> $GITHUB_ENV
-        echo "LIBS=${LIBS} ${DEP_PATH}/tre-master/lib/.libs/libtre.a" >> $GITHUB_ENV
+      - name: Build
+        run: |
+          make -j$(nproc) \
+            CXXFLAGS="-Wextra ${CXXFLAGS}" \
+            LDFLAGS="-static -static-libstdc++ ${LDFLAGS}" \
+            EXT="${EXT}"
+          ${TRIPLE}-strip ldid${EXT}
 
-    - name: build
-      run: |
-        make -j$(nproc) \
-          CXXFLAGS="-Wextra ${CXXFLAGS}" \
-          LDFLAGS="-static -static-libstdc++ ${LDFLAGS}" \
-          EXT="${EXT}"
-        ${TRIPLE}-strip ldid${EXT}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ldid_${{ env.OS }}_${{ env.ARCH }}
+          path: ldid${{ env.EXT }}
 
-    - uses: actions/upload-artifact@v1
-      with:
-        name: ldid_${{ env.OS }}_${{ env.ARCH }}
-        path: ldid${{ env.EXT }}
-
-    - name: Upload Release Asset Linux/Windows
-      uses: actions/upload-release-asset@v1
-      if: ${{ github.event_name == 'release' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ldid${{ env.EXT }}
-        asset_name: ldid_${{ env.OS }}_${{ env.ARCH }}${{ env.EXT }}
-        asset_content_type: application/octet-stream
+      - name: Upload Release Asset Linux/Windows
+        uses: actions/upload-release-asset@v1
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ldid${{ env.EXT }}
+          asset_name: ldid_${{ env.OS }}_${{ env.ARCH }}${{ env.EXT }}
+          asset_content_type: application/octet-stream
 
   build-macos:
+    name: Build
     runs-on: macos-11
     strategy:
       matrix:
@@ -192,100 +194,101 @@ jobs:
     env:
       ARCH: ${{ matrix.arch }}
       OS: ${{ matrix.os }}
+
     steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/Library/Caches/Mozilla.sccache
-          ~/dep_src
-        key: build-${{ matrix.os }}-${{ matrix.arch }}-${ { env.GITHUB_SHA } }
-        restore-keys: |
-          build-${{ matrix.os }}-${{ matrix.arch }}-
+      - name: Restore or cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/Mozilla.sccache
+            ~/dep_src
+          key: build-${{ matrix.os }}-${{ matrix.arch }}-${ { env.GITHUB_SHA } }
+          restore-keys: |
+            build-${{ matrix.os }}-${{ matrix.arch }}-
 
-    - name: setup environment
-      run: |
-        export DOWNLOAD_PATH=${HOME}/dep_src
-        export DEP_PATH=${HOME}/build
-        mkdir -p ${DOWNLOAD_PATH} ${DEP_PATH}
-        echo "DOWNLOAD_PATH=${DOWNLOAD_PATH}" >> $GITHUB_ENV
-        echo "DEP_PATH=${DEP_PATH}" >> $GITHUB_ENV
+      - name: Setup environment
+        run: |
+          export DOWNLOAD_PATH=${HOME}/dep_src
+          export DEP_PATH=${HOME}/build
+          mkdir -p ${DOWNLOAD_PATH} ${DEP_PATH}
+          echo "DOWNLOAD_PATH=${DOWNLOAD_PATH}" >> $GITHUB_ENV
+          echo "DEP_PATH=${DEP_PATH}" >> $GITHUB_ENV
 
-        if [ "${ARCH}" = "arm64" ]; then
-          echo "HOST_ARCH=aarch64" >> $GITHUB_ENV
-        else
-          echo "HOST_ARCH=${ARCH}" >> $GITHUB_ENV
-        fi
-        echo "SDK=$(xcrun -sdk ${OS} --show-sdk-path)" >> $GITHUB_ENV
+          if [ "${ARCH}" = "arm64" ]; then
+            echo "HOST_ARCH=aarch64" >> $GITHUB_ENV
+          else
+            echo "HOST_ARCH=${ARCH}" >> $GITHUB_ENV
+          fi
+          echo "SDK=$(xcrun -sdk ${OS} --show-sdk-path)" >> $GITHUB_ENV
 
-    - name: setup toolchain
-      run: |
-        brew install libtool autoconf automake
+      - name: Setup toolchain
+        run: |
+          brew install libtool autoconf automake
+          wget -nc -P ${DOWNLOAD_PATH} https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz
+          tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz -C ${HOME}
+          chmod +x ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin/sccache
 
-        # Download sccache
-        wget -nc -P ${DOWNLOAD_PATH} \
-          https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz
-        tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz -C ${HOME}
-        chmod +x ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin/sccache
+          echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
+          CC="sccache clang -arch ${ARCH} -isysroot ${SDK}"
+          CXX="sccache clang++ -arch ${ARCH} -isysroot ${SDK}"
+          if [ "${OS}" = "macosx" ]; then
+            echo "CC=${CC} -mmacosx-version-min=10.13" >> $GITHUB_ENV
+            echo "CXX=${CXX} -mmacosx-version-min=10.13" >> $GITHUB_ENV
+          else
+            echo "CC=${CC} -miphoneos-version-min=10.0" >> $GITHUB_ENV
+            echo "CXX=${CXX} -miphoneos-version-min=10.0" >> $GITHUB_ENV
+          fi
+          echo "CXXFLAGS=-Os" >> $GITHUB_ENV
+          echo "CFLAGS=-Os" >> $GITHUB_ENV
 
-        echo "${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin" >> $GITHUB_PATH
-        CC="sccache clang -arch ${ARCH} -isysroot ${SDK}"
-        CXX="sccache clang++ -arch ${ARCH} -isysroot ${SDK}"
-        if [ "${OS}" = "macosx" ]; then
-          echo "CC=${CC} -mmacosx-version-min=10.13" >> $GITHUB_ENV
-          echo "CXX=${CXX} -mmacosx-version-min=10.13" >> $GITHUB_ENV
-        else
-          echo "CC=${CC} -miphoneos-version-min=10.0" >> $GITHUB_ENV
-          echo "CXX=${CXX} -miphoneos-version-min=10.0" >> $GITHUB_ENV
-        fi
-        echo "CXXFLAGS=-Os" >> $GITHUB_ENV
-        echo "CFLAGS=-Os" >> $GITHUB_ENV
+      - name: Build libplist
+        run: |
+          wget -nc -P ${DOWNLOAD_PATH} https://github.com/libimobiledevice/libplist/releases/download/${LIBPLIST_VERSION}/libplist-${LIBPLIST_VERSION}.tar.bz2
+          tar xf ${DOWNLOAD_PATH}/libplist-${LIBPLIST_VERSION}.tar.bz2 -C ${DEP_PATH}
+          cd ${DEP_PATH}/libplist-${LIBPLIST_VERSION}
+          ./configure --host=${HOST_ARCH}-apple-darwin --without-cython --enable-static --disable-shared
+          make -j$(sysctl -n hw.ncpu)
 
-    - name: build libplist
-      run: |
-        wget -nc -P ${DOWNLOAD_PATH} https://github.com/libimobiledevice/libplist/releases/download/${LIBPLIST_VERSION}/libplist-${LIBPLIST_VERSION}.tar.bz2
-        tar xf ${DOWNLOAD_PATH}/libplist-${LIBPLIST_VERSION}.tar.bz2 -C ${DEP_PATH}
-        cd ${DEP_PATH}/libplist-${LIBPLIST_VERSION}
-        ./configure --host=${HOST_ARCH}-apple-darwin --without-cython --enable-static --disable-shared
-        make -j$(sysctl -n hw.ncpu)
+          echo "LIBPLIST_INCLUDES=-I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
+          echo "LIBPLIST_LIBS=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
 
-        echo "LIBPLIST_INCLUDES=-I${DEP_PATH}/libplist-${LIBPLIST_VERSION}/include" >> $GITHUB_ENV
-        echo "LIBPLIST_LIBS=${DEP_PATH}/libplist-${LIBPLIST_VERSION}/src/.libs/libplist-2.0.a" >> $GITHUB_ENV
+      - name: Build OpenSSL
+        run: |
+          wget -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+          tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
+          cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
+          ./config -static enable-fips enable-capieng no-module enable-ktls no-zlib \
+            no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m no-sm2 no-sm4 no-ssl3 no-seed no-weak-ssl-ciphers darwin64-${ARCH}-cc
+          make -j$(sysctl -n hw.ncpu) build_generated libcrypto.a
 
-    - name: build openssl
-      run: |
-        wget -nc -P ${DOWNLOAD_PATH} https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-        tar xf ${DOWNLOAD_PATH}/openssl-${OPENSSL_VERSION}.tar.gz -C ${DEP_PATH}
-        cd ${DEP_PATH}/openssl-${OPENSSL_VERSION}
-        ./config -static enable-fips enable-capieng no-module enable-ktls no-zlib \
-               no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m no-sm2 no-sm4 no-ssl3 no-seed no-weak-ssl-ciphers darwin64-${ARCH}-cc
-        make -j$(sysctl -n hw.ncpu) build_generated libcrypto.a
+          echo "LIBCRYPTO_INCLUDES=${CXXFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
+          echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
 
-        echo "LIBCRYPTO_INCLUDES=${CXXFLAGS} -I${DEP_PATH}/openssl-${OPENSSL_VERSION}/include" >> $GITHUB_ENV
-        echo "LIBCRYPTO_LIBS=${DEP_PATH}/openssl-${OPENSSL_VERSION}/libcrypto.a" >> $GITHUB_ENV
+      - name: Build
+        run: |
+          make -j$(sysctl -n hw.ncpu) \
+            CXXFLAGS="-flto=thin -Wextra ${CXXFLAGS}" \
+            LDFLAGS="-flto=thin"
+          strip ldid
 
-    - name: build
-      run: |
-        make -j$(sysctl -n hw.ncpu) \
-          CXXFLAGS="-flto=thin -Wextra ${CXXFLAGS}" \
-          LDFLAGS="-flto=thin"
-        strip ldid
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ldid_${{ matrix.os }}_${{ matrix.arch }}
+          path: ldid
 
-    - uses: actions/upload-artifact@v1
-      with:
-        name: ldid_${{ matrix.os }}_${{ matrix.arch }}
-        path: ldid
-
-    - name: Upload Release Asset macOS
-      uses: actions/upload-release-asset@v1
-      if: ${{ github.event_name == 'release' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ldid
-        asset_name: ldid_${{ matrix.os }}_${{ matrix.arch }}
-        asset_content_type: application/octet-stream
+      - name: Upload Release Asset macOS
+        uses: actions/upload-release-asset@v1
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ldid
+          asset_name: ldid_${{ matrix.os }}_${{ matrix.arch }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
*This was pain*

Github will begin reinforcing using Node16-based actions, as they migrate from Node 12. [The reinforcement will begin on May 18, 2023](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/). This change prevents the workflow from breaking when that date comes.

I've also taken the time to clean up the workflow, fixing up errors such as caching keys and checking out submodules (which are not in use anymore)