### PR TITLE
Makefile: Correctly clean files in rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ install: all
 	done
 
 clean:
-	rm -rf ldid *.o
+	rm -rf ldid$(EXT) *.o
 
 .PHONY: all clean install


### PR DESCRIPTION
On systems where GNU Make is present and a different extension is used at compile time, the clean rule does not correctly clean out files when requested. This change fixes such circumstance on these systems. 