### PR TITLE
Enable support for keys obtained through PKCS#11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ LIBCRYPTO_INCLUDES ?= $(shell pkg-config --cflags libcrypto)
 LIBCRYPTO_LIBS     ?= $(shell pkg-config --libs libcrypto)
 endif
 
+ifeq ($(SMARTCARD),1)
+CPPFLAGS += -DSMARTCARD
+endif
+
 MANPAGE_LANGS := zh_TW zh_CN
 
 EXT ?=

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -17,8 +17,8 @@ yubico-piv-tool -s 9c -a import-certificate -i cert.crt.pem
 yubico-piv-tool -s 9c -a import-key -i key.pem
 yubico-piv-tool -s 9c -a set-chuid
 ```
-3. You can use `p11tool --list-privkeys --login` to identify the URI for the slot (make sure that `type` is not in the URI, as seperate URIs for the cert and private key are not currently supported from the command line)
+3. You can use `p11tool --list-privkeys --login` and `p11tool --list-certs --login` to help identify the URIs for the private key and certificate
 
 ## Sign
-1. `ldid -K'pkcs11:model=YubiKey%20YK5;id=%02' -Sents.xml ls.bin`
+1. `ldid -K'pkcs11:object=Private%20key%20for%20Digital%20Signature;type=private' -X'pkcs11:object=X.509%20Certificate%20for%20Digital%20Signature;type=cert' -Sents.xml ls.bin`
 2. If the correct PKCS#11 module is not being loaded, try setting `PKCS11_MODULE_PATH` in your environment (ex. `export PKCS11_MODULE_PATH="/usr/local/lib/p11-kit-proxy.so"` or `PKCS11_MODULE_PATH="/usr/local/lib/libykcs11.so"`)

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -1,0 +1,24 @@
+## Setup
+1. Build with `make SMARTCARD=1`
+2. Install the OpenSSL engine for PKCS#11 (`libengine-pkcs11-openssl` on Debian, part of `libp11`)
+
+## Load Key Into Smartcard
+It is recommend that you generate the key on the card itself, but you can import it if needed.
+
+For yubikeys:
+1. Extract Cert and Key from p12
+```
+openssl pkcs12 -in Certificates.p12 -out cert.crt.pem -clcerts -nokeys -legacy
+openssl pkcs12 -in Certificates.p12 -out key.pem -nocerts -nodes -legacy
+```
+2. Import into Key
+```
+yubico-piv-tool -s 9c -a import-certificate -i cert.crt.pem
+yubico-piv-tool -s 9c -a import-key -i key.pem
+yubico-piv-tool -s 9c -a set-chuid
+```
+3. You can use `p11tool --list-privkeys --login` to identify the URI for the slot (make sure that `type` is not in the URI, as seperate URIs for the cert and private key are not currently supported from the command line)
+
+## Sign
+1. `ldid -K'pkcs11:model=YubiKey%20YK5;id=%02' -Sents.xml ls.bin`
+2. If the correct PKCS#11 module is not being loaded, try setting `PKCS11_MODULE_PATH` in your environment (ex. `export PKCS11_MODULE_PATH="/usr/local/lib/p11-kit-proxy.so"` or `PKCS11_MODULE_PATH="/usr/local/lib/libykcs11.so"`)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Changes from https://git.saurik.com/ldid.git:
 - Allow p12 keys to have a password (@sunflsks)
 - Add a `-arch arch_type` flag so that typing the raw CPU type is not needed
 - Proper error messages
+- Load key using PKCS#11

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -20,7 +20,7 @@
 .Op Fl H Ns Op Ar sha1 | Ar sha256
 .Op Fl h
 .Op Fl I Ns Ar name
-.Op Fl K Ns Ar key.p12 Op Fl U Ns Ar password
+.Op Fl K Ns Ar file Op Fl U Ns Ar password
 .Op Fl M
 .Op Fl P Ns Op Ar num
 .Op Fl Q Ns Ar requirements
@@ -93,14 +93,19 @@ hash types, flags, CDHash, and CodeDirectory version to
 Set the identifier used in the binaries signature to
 .Ar name .
 If not specified, the basename of the binary is used.
-.It Fl K Ns Ar key.p12
+.It Fl K Ns Ar file
 Sign using the identity in
-.Ar key.p12 .
+.Ar file .
+Must be either a
+.Ar p12
+or
+.Ar pkcs11:
+URI.
 This will give the binary a valid signature so that it can be run
 on a system with signature validation.
-If
-.Ar key.p12
-has a password you will be prompted for it,
+If the
+.Ar p12
+has a password, you will be prompted for it,
 or you can specify from the command line with
 .Fl U .
 .It Fl M

--- a/docs/ldid.1
+++ b/docs/ldid.1
@@ -20,7 +20,7 @@
 .Op Fl H Ns Op Ar sha1 | Ar sha256
 .Op Fl h
 .Op Fl I Ns Ar name
-.Op Fl K Ns Ar file Op Fl U Ns Ar password
+.Op Fl K Ns Ar file Oo Fl U Ns Ar password Oc Op Fl X Ns Ar file
 .Op Fl M
 .Op Fl P Ns Op Ar num
 .Op Fl Q Ns Ar requirements
@@ -108,6 +108,8 @@ If the
 has a password, you will be prompted for it,
 or you can specify from the command line with
 .Fl U .
+To specify the certificate separate from the private key, use
+.Fl X .
 .It Fl M
 When used with
 .Fl S ,
@@ -160,6 +162,18 @@ target is a bundle directory, and not a specific Mach-O file.
 .Fl w
 can be used on any bundle, not just the root .app, including frameworks,
 appexes, and more.
+.It Fl X Ns Ar file
+Adds
+.Ar file 
+as a certificate to be used when signing.
+The first
+.Ar file
+must be the certificate for the signing key, each additional will be added as part of the chain.
+Must be either
+.Ar DER
+encoded certificate or
+.Ar pkcs11:
+URI.
 .El
 .Sh EXAMPLES
 To fakesign

--- a/ldid.hpp
+++ b/ldid.hpp
@@ -161,6 +161,7 @@ struct Bundle {
 
 class Signer {
   public:
+    virtual ~Signer() {};
     virtual operator EVP_PKEY *() const = 0;
     virtual operator X509 *() const = 0;
     virtual operator STACK_OF(X509) *() const = 0;

--- a/ldid.hpp
+++ b/ldid.hpp
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include <openssl/x509.h>
+
 namespace ldid {
 
 // I wish Apple cared about providing quality toolchains :/
@@ -157,11 +159,19 @@ struct Bundle {
     Hash hash;
 };
 
-Bundle Sign(const std::string &root, Folder &folder, const std::string &key, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress);
+class Signer {
+  public:
+    virtual operator EVP_PKEY *() const = 0;
+    virtual operator X509 *() const = 0;
+    virtual operator STACK_OF(X509) *() const = 0;
+    virtual operator bool () const = 0;
+};
+
+Bundle Sign(const std::string &root, Folder &folder, const Signer &signer, const std::string &requirements, const Functor<std::string (const std::string &, const std::string &)> &alter, bool merge, uint8_t platform, const Progress &progress);
 
 typedef std::map<uint32_t, Hash> Slots;
 
-Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::string &identifier, const std::string &entitlements, bool merge, const std::string &requirements, const std::string &key, const Slots &slots, uint32_t flags, uint8_t platform, const Progress &progress);
+Hash Sign(const void *idata, size_t isize, std::streambuf &output, const std::string &identifier, const std::string &entitlements, bool merge, const std::string &requirements, const Signer &signer, const Slots &slots, uint32_t flags, uint8_t platform, const Progress &progress);
 
 }
 


### PR DESCRIPTION
This allows signing using a HSM or a Smartcard (ex. Yubikey)

Sponsered by: @ZonD80

## Setup
1. Build with `make SMARTCARD=1`
2. Install the OpenSSL engine for PKCS#11 (`libengine-pkcs11-openssl` on Debian, part of `libp11`)

## Load Key Into Smartcard
It is recommend that you generate the key on the card itself, but you can import it if needed.

For yubikeys:
1. Extract Cert and Key from p12
```
openssl pkcs12 -in Certificates.p12 -out cert.crt.pem -clcerts -nokeys -legacy
openssl pkcs12 -in Certificates.p12 -out key.pem -nocerts -nodes -legacy
```
2. Import into Key
```
yubico-piv-tool -s 9c -a import-certificate -i cert.crt.pem
yubico-piv-tool -s 9c -a import-key -i key.pem
yubico-piv-tool -s 9c -a set-chuid
```
3. You can use `p11tool --list-privkeys --login` to identify the URI for the slot (make sure that `type` is not in the URI, as seperate URIs for the cert and private key are not currently supported from the command line)

## Sign
1. `ldid -K'pkcs11:model=YubiKey%20YK5;id=%02' -Sents.xml ls.bin`
2. If the correct PKCS#11 module is not being loaded, try setting `PKCS11_MODULE_PATH` in your environment (ex. `export PKCS11_MODULE_PATH="/usr/local/lib/p11-kit-proxy.so"` or `PKCS11_MODULE_PATH="/usr/local/lib/libykcs11.so"`)