### PR TITLE
Update CI actions and build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ on:
       - created
 
 env:
-  LIBPLIST_VERSION: 2.2.0
-  OPENSSL_VERSION: 3.0.5
-  SCCACHE_VERSION: 0.3.0
-  TRE_COMMIT: b4dcf71e274aa2ad6a4d879d366eb20826adfecc
+  LIBPLIST_VERSION: 2.3.0
+  OPENSSL_VERSION: 3.3.1
+  SCCACHE_VERSION: 0.8.1
+  TRE_COMMIT: 98fd7804256763da06c6c8b13a7918eb7611bf4b
   MMAN_COMMIT: 2d1c576e62b99e85d99407e1a88794c6e44c3310
 
 jobs:
@@ -151,7 +151,7 @@ jobs:
           ./configure --host=${TRIPLE} --prefix=/usr --without-cython --enable-static --disable-shared
           make -j$(nproc)
 
-          echo "CXXFLAGS=${CXXFLAGS} -I${DEP_PATH}/tre-${TRE_COMMIT}/include/tre" >> $GITHUB_ENV
+          echo "CXXFLAGS=${CXXFLAGS} -DUSE_LOCAL_TRE_H -I${DEP_PATH}/tre-${TRE_COMMIT}/local_includes" >> $GITHUB_ENV
           echo "LIBS=${LIBS} ${DEP_PATH}/tre-${TRE_COMMIT}/lib/.libs/libtre.a" >> $GITHUB_ENV
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore or cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/sccache
@@ -163,7 +163,7 @@ jobs:
           ${TRIPLE}-strip ldid${EXT}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ldid_${{ env.OS }}_${{ env.ARCH }}
           path: ldid${{ env.EXT }}
@@ -178,7 +178,7 @@ jobs:
 
   build-macos:
     name: Build
-    runs-on: macos-11
+    runs-on: macos-latest
     strategy:
       matrix:
         include:
@@ -194,10 +194,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Restore or cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/Mozilla.sccache
@@ -223,7 +223,7 @@ jobs:
 
       - name: Setup toolchain
         run: |
-          brew install libtool autoconf automake
+          brew install automake
           wget -nc -P ${DOWNLOAD_PATH} https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz
           tar xf ${DOWNLOAD_PATH}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin.tar.gz -C ${HOME}
           chmod +x ${HOME}/sccache-v${SCCACHE_VERSION}-x86_64-apple-darwin/sccache
@@ -272,7 +272,7 @@ jobs:
           strip ldid
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ldid_${{ matrix.os }}_${{ matrix.arch }}
           path: ldid

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,17 +164,19 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
-          name: ldid_${{ env.OS }}_${{ env.ARCH }}
+          name: ldid_${{ env.OS }}_${{ env.ARCH }}${{ env.EXT }}
           path: ldid${{ env.EXT }}
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v1
+        uses: svenstaro/upload-release-action@v2
         if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ldid${{ env.EXT }}
+          file: ldid${{ env.EXT }}
+          asset_name: ldid_${{ env.OS }}_${{ env.ARCH }}${{ env.EXT }}
 
   build-macos:
     name: Build
@@ -273,14 +275,16 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           name: ldid_${{ matrix.os }}_${{ matrix.arch }}
           path: ldid
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v1
+        uses: svenstaro/upload-release-action@v2
         if: ${{ github.event_name == 'release' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ldid
+          file: ldid
+          asset_name: ldid_${{ matrix.os }}_${{ matrix.arch }}


### PR DESCRIPTION
Currently, the CI has several issues

- `libplist` and `openssl` have moved onto new releases
- `tre` (used on Windows targets) has had several updates
- Github no longer provides a `macos-11` runner, which prevents workflows for macOS targets from running
- Automatic release artifacts were never a thing

This PR addresses all of the issues listed above in preparation of a new (coming sometime in the future) release, as the master branch has received various new changes