### PR TITLE
replace UI_UTIL_read_pw_string with EVP_read_pw_string

### DIFF
--- a/ldid.cpp
+++ b/ldid.cpp
@@ -1885,7 +1885,7 @@ class P12Signer : public ldid::Signer {
 
         if (PKCS12_verify_mac(value_, "", 0) == 0 && !flag_U) {
             char passbuf[2048];
-            UI_UTIL_read_pw_string(passbuf, 2048, "Enter password: ", 0);
+            EVP_read_pw_string(passbuf, 2048, "Enter password: ", 0);
             password = passbuf;
         }
 


### PR DESCRIPTION
This fixes building with LibreSSL 4.0.0, which removed the UI_UTIL API.

I've done some basic testing and it seems to work identically.

Fixes #43